### PR TITLE
Set the interpreter as a version of python with docopt

### DIFF
--- a/crc-interactive.py
+++ b/crc-interactive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6 -E
+#!/usr/bin/python -E
 """crc-interactive.py -- An interactive Slurm helper
 Usage:
     crc-interactive.py (-s | -g | -m | -i | -d) [-hvzo] [-t <time>] [-n <num-nodes>]


### PR DESCRIPTION
This PR is only change I needed to make to have things work again for users. It's associated with #17, but does not resolve the issue if we want to use Python 3. 