### PR TITLE
Refactors crc-proposal-end to use base parser

### DIFF
--- a/crc-proposal-end.py
+++ b/crc-proposal-end.py
@@ -9,7 +9,7 @@ from _base_parser import BaseParser
 class CrcProposalEnd(BaseParser):
     """Command line application for printing an account's proposal end date"""
 
-    db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
+    banking_db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
 
     def __init__(self):
         """Define arguments for the command line interface"""
@@ -24,8 +24,8 @@ class CrcProposalEnd(BaseParser):
             account: The name of the account
         """
 
-        db = dataset.connect(self.db_path)
-        table = db['proposal']
+        database = dataset.connect(self.banking_db_path)
+        table = database['proposal']
 
         db_record = table.find_one(account=account)
         if db_record is None:

--- a/crc-proposal-end.py
+++ b/crc-proposal-end.py
@@ -1,48 +1,52 @@
 #!/usr/bin/env /ihome/crc/wrappers/py_wrap.sh
-"""crc-proposal-end.py -- Get SUs from crc-bank.db
-Usage:
-    crc-proposal-end.py <account> 
-    crc-proposal-end.py -h | --help
-    crc-proposal-end.py -v | --version
-
-Positional Arguments:
-    <account>       The Slurm account
-
-Options:
-    -h --help                       Print this screen and exit
-    -v --version                    Print the version of crc-proposal-end.py
-"""
-
-from os import path
+"""Print the end date for an account's proposal"""
 
 import dataset
-from docopt import docopt
 
 from _base_parser import BaseParser
 
-__version__ = BaseParser.get_semantic_version()
-__app_name__ = path.basename(__file__)
+
+class CrcProposalEnd(BaseParser):
+    """Command line application for printing an account's proposal end date"""
+
+    db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
+
+    def __init__(self):
+        """Define arguments for the command line interface"""
+
+        super(CrcProposalEnd, self).__init__()
+        self.add_argument('account', help='the Slurm account')
+
+    def get_proposal_end_date(self, account):
+        """Get the proposal end date for a given account
+
+        Args:
+            account: The name of the account
+        """
+
+        db = dataset.connect(self.db_path)
+        table = db['proposal']
+
+        db_record = table.find_one(account=account)
+        if db_record is None:
+            self.error("ERROR: The account: {0} doesn't appear to exist".format(account))
+
+        return db_record['end_date']
+
+    def app_logic(self, args):
+        """Logic to evaluate when executing the application
+
+        Args:
+            args: Parsed command line arguments
+        """
+
+        end_date = self.get_proposal_end_date(args.account)
+
+        # Format the account name and end date as an easy-to-read string
+        string_template = "Proposal ends on {1} for account {0} on H2P"
+        output_string = string_template.format(args.account, end_date.strftime("%m/%d/%y"))
+        print(output_string)
 
 
-# Test:
-# 1. Make sure item exists
-def check_item_in_table(table, account):
-    if table.find_one(account=account) is None:
-        exit("ERROR: The account: {0} doesn't appear to exist".format(account))
-
-
-# The magical mystical docopt line
-arguments = docopt(__doc__, version='{} version {}'.format(__app_name__, __version__))
-
-# Connect to the database and get the limits table
-# Absolute path ////
-db = dataset.connect('sqlite:////ihome/crc/bank/crc_bank.db')
-table = db['proposal']
-
-# Check that account exists
-check_item_in_table(table, arguments['<account>'])
-
-# Print out SUs
-string = "Proposal ends on {1} for account {0} on H2P"
-end_date = table.find_one(account=arguments['<account>'])['end_date']
-print(string.format(arguments['<account>'], end_date.strftime("%m/%d/%y")))
+if __name__ == '__main__':
+    CrcProposalEnd().execute()

--- a/crc-squeue.py
+++ b/crc-squeue.py
@@ -30,7 +30,7 @@ class CrcSqueue(BaseParser):
         """Logic to evaluate when executing the application
 
         Args:
-            args: Namespace of parsed arguments from the command line
+            args: Parsed command line arguments
         """
 
         # Variables for building shell commands

--- a/crc-sus.py
+++ b/crc-sus.py
@@ -65,7 +65,7 @@ class CrcSus(BaseParser):
         """Logic to evaluate when executing the application
 
         Args:
-            args: Namespace of parsed arguments from the command line
+            args: Parsed command line arguments
         """
 
         account_info = self.get_allocation_info(args.account)


### PR DESCRIPTION
- Refactors crc-proposal-end.py to use the `BaseParser` parent class.
- Addresses code quality inspections