### PR TITLE
Introduce dedicated method for running shell commands

### DIFF
--- a/_base_parser.py
+++ b/_base_parser.py
@@ -40,6 +40,12 @@ class BaseParser(ArgumentParser):
 
     @staticmethod
     def run_command(command):
+        """Run a command in a dedicated shell
+
+        Args:
+            command: The command to execute as a string
+        """
+
         command_list = command.split()
         process = Popen(command_list, stdout=PIPE)
         return process.communicate()

--- a/_base_parser.py
+++ b/_base_parser.py
@@ -3,6 +3,7 @@
 import abc
 import sys
 from argparse import ArgumentParser
+from subprocess import Popen, PIPE
 
 
 class BaseParser(ArgumentParser):
@@ -36,6 +37,12 @@ class BaseParser(ArgumentParser):
         """
 
         raise NotImplementedError
+
+    @staticmethod
+    def run_command(command):
+        command_list = command.split()
+        process = Popen(command_list, stdout=PIPE)
+        return process.communicate()
 
     def error(self, message):
         """Print the error message to STDOUT and exit

--- a/crc-scancel.py
+++ b/crc-scancel.py
@@ -2,7 +2,6 @@
 """A simple wrapper around the Slurm ``scancel`` command"""
 
 from os import environ
-from subprocess import Popen
 
 from readchar import readchar
 
@@ -37,7 +36,7 @@ class CrcSCancel(BaseParser):
         if job_id in stdout:
             response = readchar("Would you like to cancel job {0} on cluster {1}? (y/N): ".format(job_id, cluster))
             if response.lower() == 'y':
-                Popen(['scancel', '-M', cluster, job_id])
+                self.run_command(['scancel', '-M', cluster, job_id])
 
             print('')
 

--- a/crc-scancel.py
+++ b/crc-scancel.py
@@ -2,7 +2,7 @@
 """A simple wrapper around the Slurm ``scancel`` command"""
 
 from os import environ
-from subprocess import Popen, PIPE
+from subprocess import Popen
 
 from readchar import readchar
 
@@ -20,8 +20,7 @@ class CrcSCancel(BaseParser):
         super(CrcSCancel, self).__init__()
         self.add_argument('job_id', type=int, help='the job\'s ID')
 
-    @staticmethod
-    def cancel_job_on_cluster(user_name, cluster, job_id):
+    def cancel_job_on_cluster(self, user_name, cluster, job_id):
         """Cancel a running slurm job
 
         Args:
@@ -31,9 +30,8 @@ class CrcSCancel(BaseParser):
         """
 
         # Fetch a list of running slurm jobs matching the username and job id
-        command = ['squeue', '-h', '-u', user_name, '-j', job_id, '-M', cluster]
-        process = Popen(command, stdout=PIPE, stderr=PIPE)
-        stdout, _ = process.communicate()
+        command = 'squeue -h -u {0} -j {1} -M {2}'.format(user_name, job_id, cluster)
+        stdout = self.run_command(command)
 
         # Verify and cancel the running job
         if job_id in stdout:

--- a/crc-sinfo.py
+++ b/crc-sinfo.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env /ihome/crc/wrappers/py_wrap.sh
 """A simple wrapper around the Slurm ``sinfo`` command"""
 
-from os import system
-
 from _base_parser import BaseParser
 
 
@@ -16,7 +14,7 @@ class CrcSinfo(BaseParser):
             args: Parsed command line arguments
         """
 
-        system("sinfo -M all")
+        print(self.run_command("sinfo -M all"))
 
 
 if __name__ == '__main__':

--- a/crc-squeue.py
+++ b/crc-squeue.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env /ihome/crc/wrappers/py_wrap.sh
 """A simple wrapper around the Slurm ``squeue`` command"""
 
-from os import system, environ
+from os import environ
 
 from _base_parser import BaseParser
 
@@ -58,8 +58,7 @@ class CrcSqueue(BaseParser):
         else:
             command_options.append(self.output_user_format)
 
-        command = ' '.join(command_options)
-        system(command)
+        print(self.run_command(' '.join(command_options)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By necessity, wrapper scripts need to pipe commands to the underlying shell. However, piping shell commands introduce security vulnerabilities.

This PR introduces a dedicated method to the base parser (`BaseParser.run_command`) for executing shell commands. This isn't inherently safer except it ensures consistency in how shell commands are run. If we do decide to improve security (somehow), we will only need to make changes in one place.

This change also decreases the number of security warnings from the QA tool which is nice.