### PR TITLE
Moves duplicate, hardcoded settings into dedicated class

### DIFF
--- a/_base_parser.py
+++ b/_base_parser.py
@@ -14,7 +14,7 @@ class CommonSettings(object):
     cluster_partitions = {
         'smp': ['smp', 'high-mem', "legacy"],
         'gpu': ['gtx1080', 'titanx', 'titan', 'k40'],
-        'mpi': ['opa', 'ib', "opa-high-mem"],
+        'mpi': ['mpi', 'opa', 'ib', "opa-high-mem"],
         'htc': ['htc']
     }
 

--- a/_base_parser.py
+++ b/_base_parser.py
@@ -7,6 +7,18 @@ from os import path
 from subprocess import Popen, PIPE
 
 
+class CommonSettings(object):
+    """Parent class for adding common settings to a command line application"""
+
+    banking_db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
+    cluster_partitions = {
+        'smp': ['smp', 'high-mem', "legacy"],
+        'gpu': ['gtx1080', 'titanx', 'titan', 'k40'],
+        'mpi': ['opa', 'ib', "opa-high-mem"],
+        'htc': ['htc']
+    }
+
+
 class BaseParser(ArgumentParser):
     """Base class for building command line applications"""
 

--- a/crc-idle.py
+++ b/crc-idle.py
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE
 
 from docopt import docopt
 
-from _base_parser import BaseParser
+from _base_parser import BaseParser, CommonSettings
 
 __version__ = BaseParser.get_semantic_version()
 __app_name__ = path.basename(__file__)
@@ -138,12 +138,7 @@ def cpu_logic(cluster, partition):
 
 arguments = docopt(__doc__, version='{} version {}'.format(__app_name__, __version__))
 
-CLUSTERS = {
-    "smp": ["smp", "high-mem", "legacy"],
-    "gpu": ["gtx1080", "titanx", "k40", "v100"],
-    "mpi": ["opa", "opa-high-mem", "ib"],
-    "htc": ["htc"],
-}
+CLUSTERS = CommonSettings.cluster_partitions
 
 # Arguments Check
 # ===============

--- a/crc-proposal-end.py
+++ b/crc-proposal-end.py
@@ -3,13 +3,11 @@
 
 import dataset
 
-from _base_parser import BaseParser
+from _base_parser import BaseParser, CommonSettings
 
 
-class CrcProposalEnd(BaseParser):
+class CrcProposalEnd(BaseParser, CommonSettings):
     """Command line application for printing an account's proposal end date"""
-
-    banking_db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
 
     def __init__(self):
         """Define arguments for the command line interface"""

--- a/crc-scancel.py
+++ b/crc-scancel.py
@@ -5,13 +5,11 @@ from os import environ
 
 from readchar import readchar
 
-from _base_parser import BaseParser
+from _base_parser import BaseParser, CommonSettings
 
 
-class CrcSCancel(BaseParser):
+class CrcSCancel(BaseParser, CommonSettings):
     """Command line application for canceling the user's running slurm jobs"""
-
-    clusters = ['smp', 'gpu', 'mpi', 'htc', 'invest']
 
     def __init__(self):
         """Define arguments for the command line interface"""
@@ -48,7 +46,7 @@ class CrcSCancel(BaseParser):
         """
 
         user = environ['USER']
-        for cluster in self.clusters:
+        for cluster in self.cluster_partitions:
             self.cancel_job_on_cluster(user, cluster, args.job_id)
 
 

--- a/crc-scontrol.py
+++ b/crc-scontrol.py
@@ -1,18 +1,11 @@
 #!/usr/bin/env /ihome/crc/wrappers/py_wrap.sh
 """A simple wrapper around the Slurm ``scontrol`` command"""
 
-from _base_parser import BaseParser
+from _base_parser import BaseParser, CommonSettings
 
 
-class CrcScontrol(BaseParser):
+class CrcScontrol(BaseParser, CommonSettings):
     """Command line application for fetching data from the Slurm ``scontrol`` utility"""
-
-    cluster_partitions = {
-        'smp': ['smp', 'high-mem', "legacy"],
-        'gpu': ['gtx1080', 'titanx', 'titan', 'k40'],
-        'mpi': ['opa', 'ib', "opa-high-mem"],
-        'htc': ['htc']
-    }
 
     def __init__(self):
         """Define arguments for the command line interface"""

--- a/crc-sus.py
+++ b/crc-sus.py
@@ -3,15 +3,12 @@
 
 import dataset
 
-from _base_parser import BaseParser
+from _base_parser import BaseParser, CommonSettings
 
 
-class CrcSus(BaseParser):
+class CrcSus(BaseParser, CommonSettings):
     """Command line application for printing an account's service unit allocation"""
 
-    # Application settings
-    cluster_names = ('smp', 'gpu', 'mpi', 'htc')
-    banking_db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
 
     def __init__(self):
         """Define arguments for the command line interface"""
@@ -38,7 +35,7 @@ class CrcSus(BaseParser):
         if db_record is None:
             self.error('ERROR: No proposal for the given account was found')
 
-        allocations = {cluster: db_record[cluster] for cluster in self.cluster_names}
+        allocations = {cluster: db_record[cluster] for cluster in self.cluster_partitions}
         return allocations
 
     @staticmethod


### PR DESCRIPTION
Resolves #16 

This PR adds the `mpi` partition to the `mpi` cluster. Instead of making changes to multiple hardcoded values, I moved common application settings into a `CommonSettings` class.