### PR TITLE
Simplify crc-scancel app

### DIFF
--- a/crc-scancel.py
+++ b/crc-scancel.py
@@ -8,36 +8,52 @@ from sys import stdout
 from _base_parser import BaseParser, CommonSettings
 
 
-class CrcSCancel(BaseParser, CommonSettings):
+class CrcScancel(BaseParser, CommonSettings):
     """Command line application for canceling the user's running slurm jobs"""
+
+    user = environ['USER']
 
     def __init__(self):
         """Define arguments for the command line interface"""
 
-        super(CrcSCancel, self).__init__()
+        super(CrcScancel, self).__init__()
 
         # Argument must be a valid integer expressed as a string
         int_as_str = lambda x: str(int(x))
         self.add_argument('job_id', type=int_as_str, help='the job\'s ID')
 
-    def cancel_job_on_cluster(self, user_name, cluster, job_id):
+    @staticmethod
+    def cancel_job_on_cluster(cluster, job_id):
         """Cancel a running slurm job
 
         Args:
-            user_name: The name of the user who submitted the job
             cluster: The name of the cluster the job is running on
             job_id: The ID of the slurm job to cancel
         """
 
-        # Fetch a list of running slurm jobs matching the username and job id
-        process = Popen(['squeue', '-h', '-u', user_name, '-j', job_id, '-M', cluster], stdout=PIPE, stderr=PIPE)
-        cmd_out, _ = process.communicate()
+        Popen(['scancel', '-M', cluster, job_id])
 
-        # Verify and cancel the running job
-        if job_id in cmd_out:
-            stdout.write("Would you like to cancel job {0} on cluster {1}? (y/N): ".format(job_id, cluster))
-            if self.readchar().lower() == 'y':
-                Popen(['scancel', '-M', cluster, job_id])
+    def get_cluster_for_job_id(self, job_id):
+        """Return the name of the cluster a slurm job is running on
+
+        Exits the application with an error
+        """
+
+        # In principle the cluster name can be fetched by running
+        #   squeue -h -j job_id
+        # However, that approach fails for scavenger jobs. Instead, we iterate
+        # over the clusters until we find the right one.
+
+        for cluster in self.cluster_partitions:
+            # Fetch a list of running slurm jobs matching the username and job id
+            command = ['squeue', '-h', '-u', self.user, '-j', job_id, '-M', cluster]
+            process = Popen(command, stdout=PIPE, stderr=PIPE)
+            command_out, _ = process.communicate()
+
+            if job_id in command_out:
+                return cluster
+
+        return None
 
     def app_logic(self, args):
         """Logic to evaluate when executing the application
@@ -46,10 +62,14 @@ class CrcSCancel(BaseParser, CommonSettings):
             args: Namespace of parsed arguments from the command line
         """
 
-        user = environ['USER']
-        for cluster in self.cluster_partitions:
-            self.cancel_job_on_cluster(user, cluster, args.job_id)
+        cluster = self.get_cluster_for_job_id(args.job_id)
+        if not cluster:
+            self.error('Could not find job {} running on known clusters'.format(args.job_id))
+
+        stdout.write("Would you like to cancel job {0} on cluster {1}? (y/N): ".format(args.job_id, cluster))
+        if self.readchar().lower() == 'y':
+            self.cancel_job_on_cluster(cluster, args.job_id)
 
 
 if __name__ == '__main__':
-    CrcSCancel().execute()
+    CrcScancel().execute()

--- a/tests/test_crc_scancel.py
+++ b/tests/test_crc_scancel.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-CrcSCancel = __import__('crc-scancel').CrcSCancel
+CrcScancel = __import__('crc-scancel').CrcScancel
 
 
 class ArgumentParsing(TestCase):
@@ -16,7 +16,7 @@ class ArgumentParsing(TestCase):
         """
 
         job_id = '1234'
-        args, unknown_args = CrcSCancel().parse_known_args([job_id])
+        args, unknown_args = CrcScancel().parse_known_args([job_id])
 
         self.assertFalse(unknown_args)
         self.assertEqual(job_id, args.job_id)


### PR DESCRIPTION
I've done a refactoring pass on `crc-scancel` to better align methods with the SRP. Not a big change, but it's a small step toward better test coverage and maintainability.