### PR TITLE
Improves formatting of crc-interactive help text

### DIFF
--- a/_base_parser.py
+++ b/_base_parser.py
@@ -5,7 +5,7 @@ import os
 import sys
 import termios
 import tty
-from argparse import ArgumentParser
+from argparse import ArgumentParser, HelpFormatter
 from subprocess import Popen, PIPE
 
 
@@ -24,11 +24,17 @@ class CommonSettings(object):
 class BaseParser(ArgumentParser):
     """Base class for building command line applications"""
 
+    # Maximum starting point of help text argument descriptions
+    help_width = 50
+
     def __init__(self):
         """Define arguments for the command line interface"""
 
         super(BaseParser, self).__init__()
         self.add_argument('-v', '--version', action='version', version=self.app_version)
+
+    def _get_formatter(self) -> HelpFormatter:
+        return HelpFormatter(self.prog, max_help_position=self.help_width)
 
     # TODO: Merge this into app_version once all apps are using the base parser
     @staticmethod

--- a/crc-interactive.py
+++ b/crc-interactive.py
@@ -30,6 +30,7 @@ class CrcInteractive(BaseParser, CommonSettings):
     max_time = 12  # Maximum limit on requested time in hours
 
     default_time = 1  # Default runtime
+    default_nodes = 1  # Default number of nodes
     default_cores = 1  # Default number of requested cores
     default_mem = 1  # Default memory in GB
     default_gpus = 0  # Default number of GPUs
@@ -38,24 +39,43 @@ class CrcInteractive(BaseParser, CommonSettings):
         """Define arguments for the command line interface"""
 
         super(CrcInteractive, self).__init__()
-        self.add_argument('-s', '--smp', action='store_true', help='Interactive job on smp cluster')
-        self.add_argument('-g', '--gpu', action='store_true', help='Interactive job on gpu cluster')
-        self.add_argument('-m', '--mpi', action='store_true', help='Interactive job on mpi cluster')
-        self.add_argument('-i', '--invest', action='store_true', help='Interactive job on invest cluster')
-        self.add_argument('-d', '--htc', action='store_true', help='Interactive job on htc cluster')
-
-        self.add_argument('-t', '--time', type=int, default=1, help='Run time in hours [default: 1]')
-        self.add_argument('-n', '--num-nodes', type=int, default=self.default_time, help='Number of nodes [default: 1]')
-        self.add_argument('-p', '--partition', help='Specify non-default partition')
-        self.add_argument('-c', '--num-cores', type=int, default=self.default_cores, help='Number of cores per node [default: 1]')
-        self.add_argument('-u', '--num-gpus', type=int, default=self.default_gpus, help='If using -g, the number of GPUs [default: 0]')
-        self.add_argument('-r', '--reservation', help='Specify a reservation name')
-        self.add_argument('-b', '--mem', type=int, default=self.default_mem, help='Memory in GB')
-        self.add_argument('-a', '--account', help='Specify a non-default account')
-        self.add_argument('-l', '--license', help='Specify a license')
-        self.add_argument('-f', '--feature', help='Specify a feature, e.g. `ti` for GPUs')
         self.add_argument('-z', '--print-command', action='store_true', help='Simply print the command to be run')
-        self.add_argument('-o', '--openmp', action='store_true', help='Run using OpenMP style submission')
+
+        # Arguments for specifying what cluster to start an interactive session on
+        cluster_args = self.add_argument_group('Cluster Arguments')
+        cluster_args.add_argument('-s', '--smp', action='store_true', help='Interactive job on smp cluster')
+        cluster_args.add_argument('-g', '--gpu', action='store_true', help='Interactive job on gpu cluster')
+        cluster_args.add_argument('-m', '--mpi', action='store_true', help='Interactive job on mpi cluster')
+        cluster_args.add_argument('-i', '--invest', action='store_true', help='Interactive job on invest cluster')
+        cluster_args.add_argument('-d', '--htc', action='store_true', help='Interactive job on htc cluster')
+        cluster_args.add_argument('-p', '--partition', help='Specify non-default partition')
+
+        # Arguments for requesting additional hardware resources
+        resource_args = self.add_argument_group('Arguments for Increased Resources')
+        resource_args.add_argument('-b', '--mem', type=int, default=self.default_mem, help='Memory in GB')
+        resource_args.add_argument(
+            '-t', '--time', type=int, default=self.default_time,
+            help='Run time in hours [default: {}]'.format(self.default_time))
+
+        resource_args.add_argument(
+            '-n', '--num-nodes', type=int, default=self.default_nodes,
+            help='Number of nodes [default: {}]'.format(self.default_nodes))
+
+        resource_args.add_argument(
+            '-c', '--num-cores', type=int, default=self.default_cores,
+            help='Number of cores per node [default: {}]'.format(self.default_cores))
+
+        resource_args.add_argument(
+            '-u', '--num-gpus', type=int, default=self.default_gpus,
+            help='If using -g, the number of GPUs [default: {}]'.format(self.default_gpus))
+
+        # A grab bag of other settings for configuring slurm jobs
+        additional_args = self.add_argument_group('Additional Job Settings')
+        additional_args.add_argument('-a', '--account', help='Specify a non-default account')
+        additional_args.add_argument('-r', '--reservation', help='Specify a reservation name')
+        additional_args.add_argument('-l', '--license', help='Specify a license')
+        additional_args.add_argument('-f', '--feature', help='Specify a feature, e.g. `ti` for GPUs')
+        additional_args.add_argument('-o', '--openmp', action='store_true', help='Run using OpenMP style submission')
 
     def _validate_arguments(self, args):
         """Exit the application if command-line arguments are invalid
@@ -65,7 +85,7 @@ class CrcInteractive(BaseParser, CommonSettings):
         """
 
         # Check wall time is between limits
-        if not (self.min_time <= args.time <= self.max_time):
+        if not self.min_time <= args.time <= self.max_time:
             self.error('{} is not in {} <= time <= {}... exiting'.format(args.time, self.min_time, self.max_time))
 
         # Check the minimum number of nodes are requested for mpi


### PR DESCRIPTION
- Default values for `crc-interactive` are now set in the help text dynamically
- Fixed a bug where the default number of nodes was set incorrectly from application-level settings
- Arguments for `crc-interactive` are now grouped together by category in the help text.
- The width of the help text has been increased for all apps to ensure easier readability