### PR TITLE
Determines cluster partition names dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ git fetch
 git checkout tags/[RELEASETAG]
 ```
 
-If you need to rollback to an earlier version, use the same `git` commands lsited above but with the appropraite tag. 
+If you need to roll back to an earlier version, use the same `git` commands listed above but with the appropriate tag. 

--- a/_base_parser.py
+++ b/_base_parser.py
@@ -14,12 +14,7 @@ class CommonSettings(object):
     """Parent class for adding common settings to a command line application"""
 
     banking_db_path = 'sqlite:////ihome/crc/bank/crc_bank.db'
-    cluster_partitions = {
-        'smp': ['smp', 'high-mem', "legacy"],
-        'gpu': ['gtx1080', 'titanx', 'titan', 'k40'],
-        'mpi': ['mpi', 'opa', 'ib', "opa-high-mem"],
-        'htc': ['htc']
-    }
+    cluster_names = ('smp', 'gpu', 'mpi', 'htc')
 
 
 class BaseParser(ArgumentParser):

--- a/crc-idle.py
+++ b/crc-idle.py
@@ -138,7 +138,7 @@ def cpu_logic(cluster, partition):
 
 arguments = docopt(__doc__, version='{} version {}'.format(__app_name__, __version__))
 
-CLUSTERS = CommonSettings.cluster_partitions
+CLUSTERS = CommonSettings.cluster_names
 
 # Arguments Check
 # ===============

--- a/crc-interactive.py
+++ b/crc-interactive.py
@@ -147,7 +147,7 @@ class CrcInteractive(BaseParser, CommonSettings):
         if self.x11_is_available():
             srun_args += ' --x11 '
 
-        cluster_to_run = next(cluster for cluster in self.cluster_partitions if getattr(args, cluster))
+        cluster_to_run = next(cluster for cluster in self.cluster_names if getattr(args, cluster))
         return 'srun -M {} {} --pty bash'.format(cluster_to_run, srun_args)
 
     def app_logic(self, args):
@@ -157,7 +157,7 @@ class CrcInteractive(BaseParser, CommonSettings):
             args: Parsed command line arguments
         """
 
-        if not any(getattr(args, cluster) for cluster in self.cluster_partitions):
+        if not any(getattr(args, cluster) for cluster in self.cluster_names):
             self.print_help()
             self.exit()
 

--- a/crc-job-stats.py
+++ b/crc-job-stats.py
@@ -33,7 +33,7 @@ class CrcJobStats(BaseParser):
         for idx, item in enumerate(split_output):
             if '=' not in item:
                 drop_indices.append(idx)
-                split_output[idx - 1] += '\ ' + item
+                split_output[idx - 1] += r'\ ' + item
 
         for drop_idx in reversed(sorted(drop_indices)):
             del split_output[drop_idx]

--- a/crc-scancel.py
+++ b/crc-scancel.py
@@ -44,7 +44,7 @@ class CrcScancel(BaseParser, CommonSettings):
         # However, that approach fails for scavenger jobs. Instead, we iterate
         # over the clusters until we find the right one.
 
-        for cluster in self.cluster_partitions:
+        for cluster in self.cluster_names:
             # Fetch a list of running slurm jobs matching the username and job id
             command = ['squeue', '-h', '-u', self.user, '-j', job_id, '-M', cluster]
             process = Popen(command, stdout=PIPE, stderr=PIPE)

--- a/crc-scontrol.py
+++ b/crc-scontrol.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env /ihome/crc/wrappers/py_wrap.sh
 """A simple wrapper around the Slurm ``scontrol`` command"""
+import re
 
 from _base_parser import BaseParser, CommonSettings
 
@@ -12,7 +13,7 @@ class CrcScontrol(BaseParser, CommonSettings):
 
         super(CrcScontrol, self).__init__()
 
-        valid_clusters = tuple(self.cluster_partitions)
+        valid_clusters = tuple(self.cluster_names)
         self.add_argument(
             '-c', '--cluster',
             required=True,
@@ -20,6 +21,21 @@ class CrcScontrol(BaseParser, CommonSettings):
             help='print partitions for the given cluster')
 
         self.add_argument('-p', '--partition', help='print information about nodes in the given partition')
+
+    @staticmethod
+    def _slurm_cluster_partitions(cluster_name):
+        """Return a tuple of partition names associated with a given slurm cluster
+
+        Args:
+            cluster_name: The name of a slurm cluster
+
+        Returns:
+            A tuple of partition names
+        """
+
+        output = BaseParser.run_command("scontrol -M {} show partition".format(cluster_name))
+        regex_pattern = re.compile(r'PartitionName=(\w*)')
+        return tuple(re.findall(regex_pattern, output))
 
     def get_partition_info(self, cluster, partition):
         """Return a dictionary of Slurm settings as configured on a given partition
@@ -72,7 +88,7 @@ class CrcScontrol(BaseParser, CommonSettings):
         """
 
         if args.partition:
-            if args.partition not in self.cluster_partitions[args.cluster]:
+            if args.partition not in self._slurm_cluster_partitions(args.cluster):
                 self.error('Partition {} is not part of cluster {}'.format(args.partition, args.cluster))
 
             self.print_node(args.cluster, args.partition)

--- a/crc-sus.py
+++ b/crc-sus.py
@@ -34,7 +34,7 @@ class CrcSus(BaseParser, CommonSettings):
         if db_record is None:
             self.error('ERROR: No proposal for the given account was found')
 
-        allocations = {cluster: db_record[cluster] for cluster in self.cluster_partitions}
+        allocations = {cluster: db_record[cluster] for cluster in self.cluster_names}
         return allocations
 
     def build_output_string(self, account, **allocation):
@@ -49,9 +49,9 @@ class CrcSus(BaseParser, CommonSettings):
         """
 
         output_lines = ['Account {}'.format(account)]
-        cluster_name_length = max(len(cluster) for cluster in self.cluster_partitions)
+        cluster_name_length = max(len(cluster) for cluster in self.cluster_names)
 
-        for cluster in self.cluster_partitions:
+        for cluster in self.cluster_names:
             cluster_name = cluster.rjust(cluster_name_length)
             output_lines.append(' cluster {} has {} SUs'.format(cluster_name, allocation.get(cluster, 0)))
 

--- a/tests/test_crc_quota.py
+++ b/tests/test_crc_quota.py
@@ -6,7 +6,7 @@ AbstractQuota = __import__('crc-quota').AbstractFilesystemUsage
 
 
 class BytesUnitConversion(unittest.TestCase):
-    """Test the conversion of bytes into human readable units"""
+    """Test the conversion of bytes into human-readable units"""
 
     def test_zero_bytes(self):
         """Test the conversion of zero bytes"""

--- a/tests/test_crc_scontrol.py
+++ b/tests/test_crc_scontrol.py
@@ -15,7 +15,7 @@ class ArgumentParsing(TestCase):
 
         app = CrcScontrol()
 
-        for cluster in CommonSettings.cluster_partitions:
+        for cluster in CommonSettings.cluster_names:
             known_args, unknown_args = app.parse_known_args(['--cluster', cluster])
             self.assertEqual(cluster, known_args.cluster)
             self.assertFalse(unknown_args)


### PR DESCRIPTION
Upcoming maintenance will retire some of the cluster partitions. We've had trouble in the past with keeping hardcoded partition names up to date. This PR determines partition names dynamically.