### PR TITLE
Automatically gather partition list for crc-idle

### DIFF
--- a/crc-idle.py
+++ b/crc-idle.py
@@ -65,10 +65,12 @@ class CrcIdle(BaseParser, CommonSettings):
         self.partition_names = tuple([line.split('=')[1] for line in partition_info if 'PartitionName=' in line])
 
         # Default to returning all partitions
-        import pdb; pdb.set_trace()
-        argument_partitions = tuple(filter(lambda partition: partition in vars(args)['partition'], self.partition_names))
+        if not vars(args)['partition']:
+            partitions = self.partition_names
+        else:
+            partitions = tuple(filter(lambda partition: partition in vars(args)['partition'], self.partition_names))
 
-        return argument_partitions or self.partition_names
+        return partitions
         
 
     def _idle_cpu_resources(self, cluster, partition):

--- a/crc-idle.py
+++ b/crc-idle.py
@@ -93,7 +93,7 @@ class CrcIdle(BaseParser, CommonSettings):
             node_name, resource_data = node_info.split(',')
             # Return values include: allocated, idle, other, total
             _, idle, _, _ = [int(x) for x in resource_data.split('/')]
-            return_dict = return_dict.set_default(idle,0) + 1
+            return_dict[idle] = return_dict.setdefault(idle,0) + 1
 
         return return_dict
 
@@ -121,7 +121,7 @@ class CrcIdle(BaseParser, CommonSettings):
             allocated = int(allocated[-1:])
             total = int(total[-1:])
             idle = total - allocated
-            return_dict = return_dict.setdefault(idle,0) + 1
+            return_dict[idle] = return_dict.setdefault(idle,0) + 1
 
         return return_dict
 


### PR DESCRIPTION
Added some logic to crc-idle for determining partition information from `scontrol show partition`. We can work this out into something that the other wrappers can use if that seems like a good idea. I wasn't sure how to do that in BaseParser...