### PR TITLE
Add logic to GPU counting to account for drain state

### DIFF
--- a/crc-idle.py
+++ b/crc-idle.py
@@ -99,7 +99,6 @@ class CrcIdle(BaseParser, CommonSettings):
             
             #If the node is in a downed state, report 0 resource availability. 
             if state in ['drain']:
-                import pdb; pdb.set_trace()
                 idle = 0
             else:
                 allocated = int(allocated[-1:])

--- a/crc-idle.py
+++ b/crc-idle.py
@@ -46,7 +46,7 @@ class CrcIdle(BaseParser, CommonSettings):
         return argument_clusters or self.cluster_names
 
     def _idle_cpu_resources(self, cluster, partition):
-        """Return the idle CPU resources on a given cluster partition. 
+        """Return the idle CPU resources on a given cluster partition 
 
         Args:
             cluster: The cluster to print a summary for
@@ -65,7 +65,6 @@ class CrcIdle(BaseParser, CommonSettings):
         return_dict = dict()
         for node_info in slurm_data:
             node_name, resource_data = node_info.split(',')
-
             # Return values include: allocated, idle, other, total
             _, idle, _, _ = [int(x) for x in resource_data.split('/')]
             
@@ -74,7 +73,8 @@ class CrcIdle(BaseParser, CommonSettings):
         return return_dict
 
     def _idle_gpu_resources(self, cluster, partition):
-        """Return the idle GPU resources on a given cluster partition.
+        """Return the idle GPU resources on a given cluster partition
+           
            If the host node is in 'drain' state, the GPUs are reported as unavailable.
 
         Args:
@@ -86,7 +86,6 @@ class CrcIdle(BaseParser, CommonSettings):
         """
 
         # Use `sinfo` command to determine the status of each node in the given partition
-       # command = 'sinfo -h -M {0} -p {1} -N --Format=NodeList:_,gres:5,gresUsed:12'.format(cluster, partition)
         command = "sinfo -h -M {0} -p {1} -N --Format=NodeList:'_',gres:5'_',gresUsed:12'_',StateCompact:' '".format(cluster, partition)
         stdout = self.run_command(command)
         slurm_data = stdout.strip().split()
@@ -97,7 +96,7 @@ class CrcIdle(BaseParser, CommonSettings):
             # node_name, total, allocated, node state
             _, total, allocated, state = node_info.split('_')
             
-            #If the node is in a downed state, report 0 resource availability. 
+            # If the node is in a downed state, report 0 resource availability.
             if state in ['drain']:
                 idle = 0
             else:

--- a/crc-idle.py
+++ b/crc-idle.py
@@ -69,8 +69,7 @@ class CrcIdle(BaseParser):
         for node_info in slurm_data:
             node_name, resource_data = node_info.split(',')
             # Return values include: allocated, idle, other, total
-            _, idle, _, _ = [int(x) for x in resource_data.split('/')]
-            
+            _, idle, _, _ = [int(x) for x in resource_data.split('/')] 
             return_dict[idle] = return_dict.setdefault(idle,0) + 1
 
         return return_dict


### PR DESCRIPTION
I don't think #14 fully resolved #6, as GPUs from gpu-stage08 still show as usable by crc-idle.
This adds an additional output format item to the sinfo call to report host node state, and then if the state is drain, sets the number of idle GPUs to zero. 

Not an issue for the other clusters, as drain state CPU A/I/O/T reports idle as 0.

I'm pretty slurm does not allocate jobs on nodes in the drain state, so this will prevent confusion there. 