### PR TITLE
Formatting updates to rendered HTML docs

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -62,11 +62,15 @@ class is located in ``apps/example_module.py`` and exposes the application as
 an executable called ``executable-name``:
 
 .. code-block::
+
    setup(
+       ...
        entry_points=\"""
            [console_scripts]
            executable-name=apps.example_module:ExampleApplication.execute
        \"""
+       ...
+   )
 """
 
 __version__ = '0.4.0'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,9 +6,12 @@ import sys
 
 from pathlib import Path
 
+# Add the project source code to the working python environment
 conf_dir = Path(__file__).resolve().parent
-source_dir = conf_dir.parent.parent
-sys.path.insert(0, str(source_dir))
+project_root = conf_dir.parent.parent
+apps_dir = project_root / 'apps'
+
+sys.path.insert(0, str(project_root))
 
 # -- Project information -----------------------------------------------------
 
@@ -29,7 +32,7 @@ extensions = [
 
 # Configure automatic documentation of commandline applications
 autoapi_type = 'python'
-autoapi_dirs = [str(source_dir / 'apps')]
+autoapi_dirs = [str(apps_dir)]
 autoapi_add_toctree_entry = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,16 +27,14 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'autoapi.extension'
+    'autoapi.extension',
 ]
 
 # Configure automatic documentation of commandline applications
 autoapi_type = 'python'
 autoapi_dirs = [str(apps_dir)]
 autoapi_add_toctree_entry = False
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+autoapi_template_dir = 'templates'
 
 # The suffix(es) of source filenames.
 source_suffix = '.rst'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ author = u'Pitt Center for Research Computing'
 # Add any Sphinx extension module names here, as strings.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',

--- a/docs/source/templates/python/module.rst
+++ b/docs/source/templates/python/module.rst
@@ -1,0 +1,34 @@
+{% if not obj.display %}
+:orphan:
+
+{% endif %}
+{{ obj.name }}
+=========={{ "=" * obj.name|length }}
+
+.. py:module:: {{ obj.name }}
+
+{% if obj.docstring %}
+.. autoapi-nested-parse::
+
+   {{ obj.docstring|indent(3) }}
+
+{% endif %}
+
+{% block content %}
+
+{% if obj.all is not none %}
+{% set visible_children = obj.children|selectattr("short_name", "in", obj.all)|list %}
+{% else %}
+{% set visible_children = obj.children|selectattr("display")|rejectattr("imported")|list %}
+{% endif %}
+
+{% if visible_children %}
+Module Contents
+---------------
+
+{% for obj_item in visible_children %}
+{{ obj_item.render()|indent(0) }}
+{% endfor %}
+
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
- Fixed error where the example for editing `setup.py` does not render
- Adds a custom template for module documentation that creates cleaner rendered documentation
- Enables the Napolean extension so google style docs render correctly.