### PR TITLE
Disable WAL for DB queries

### DIFF
--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -31,7 +31,7 @@ class CrcProposalEnd(BaseParser):
             account: The name of the account
         """
 
-        database = dataset.connect(self.banking_db_path)
+        database = dataset.connect(self.banking_db_path, sqlite_wal_mode=False)
         table = database['proposal']
 
         db_record = table.find_one(account=account)

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -1,5 +1,5 @@
 """Print an account's service unit allocation"""
-import sqlite3
+
 from argparse import Namespace
 from typing import Dict
 

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -1,5 +1,5 @@
 """Print an account's service unit allocation"""
-
+import sqlite3
 from argparse import Namespace
 from typing import Dict
 
@@ -34,7 +34,7 @@ class CrcSus(BaseParser):
         """
 
         # Connect to the database and get the table with proposal service units
-        database = dataset.connect(self.banking_db_path)
+        database = dataset.connect(self.banking_db_path, sqlite_wal_mode=False)
         table = database['proposal']
 
         # Ensure a proposal exists for the given account


### PR DESCRIPTION
WAL is enabled in the `dataset` package by default. This causes problems when working against sqlite DBs that are read only.