### PR TITLE
Fetch package meta dynamically when building docs

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -2,3 +2,4 @@
 
 __version__ = '0.4.0'
 __author__ = 'Pitt Center for Research Computing'
+__copyright__ = '2022, Pitt Center for Research Computing'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(project_root))
 
 from apps import __version__, __author__, __copyright__
 
-project = u'CRC Wrapper Applications'
+project = 'CRC Wrapper Applications'
 copyright = __copyright__
 author = __author__
 release = __version__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,9 +15,12 @@ sys.path.insert(0, str(project_root))
 
 # -- Project information -----------------------------------------------------
 
+from apps import __version__, __author__, __copyright__
+
 project = u'CRC Wrapper Applications'
-copyright = u'2022, Pitt Center for Research Computing'
-author = u'Pitt Center for Research Computing'
+copyright = __copyright__
+author = __author__
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Uses package metadata from the application __init__ file when building the docs.

I've included the author, version, and copyright