### PR TITLE
Update time format for crc-interactive

### DIFF
--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -85,7 +85,9 @@ class CrcInteractive(BaseParser):
         if args.time.isdecimal():
             check_time = int(args.time)
         else:
-            check_time = datetime.strptime(args.time, '%H:%M').hour + float(datetime.strptime(args.time, '%H:%M').minute) // 60
+            check_time = (
+                datetime.strptime(args.time, '%H:%M').hour +
+                datetime.strptime(args.time, '%H:%M').minute / 60)
 
         if not self.min_time <= check_time <= self.max_time:
             self.error(f'{check_time} is not in {self.min_time} <= time <= {self.max_time}... exiting')

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -23,7 +23,7 @@ class CrcInteractive(BaseParser):
     min_time = 1  # Minimum limit on requested time in hours
     max_time = 12  # Maximum limit on requested time in hours
 
-    default_time = 1  # Default runtime
+    default_time = '1'  # Default runtime
     default_nodes = 1  # Default number of nodes
     default_cores = 1  # Default number of requested cores
     default_mem = 1  # Default memory in GB
@@ -51,7 +51,7 @@ class CrcInteractive(BaseParser):
         resource_args = self.add_argument_group('Arguments for Increased Resources')
         resource_args.add_argument('-b', '--mem', type=int, default=self.default_mem, help='memory in GB')
         resource_args.add_argument(
-            '-t', '--time',  default=str(self.default_time),
+            '-t', '--time',  default=self.default_time,
             help=f'run time in hours [default: {self.default_time}]')
 
         resource_args.add_argument(

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -52,7 +52,7 @@ class CrcInteractive(BaseParser):
         resource_args.add_argument('-b', '--mem', type=int, default=self.default_mem, help='memory in GB')
         resource_args.add_argument(
             '-t', '--time',  default=self.default_time,
-            help=f'run time in hours [default: {self.default_time}]')
+            help=f'run time in hours or hours:minutes [default: {self.default_time}]')
 
         resource_args.add_argument(
             '-n', '--num-nodes', type=int, default=self.default_nodes,
@@ -83,8 +83,8 @@ class CrcInteractive(BaseParser):
 
         # Check wall time is between limits, enable both %H:%M format as well as integer hours
         check_time=0
-        if args.time.find(':')<0:
-            check_time=int(args.time)
+        if  args.time.isdecimal()::
+            check_time=int(args.time)+1
         else:
             check_time=datetime.strptime(args.time,'%H:%M').hour
             
@@ -113,7 +113,7 @@ class CrcInteractive(BaseParser):
         srun_dict = {
             'partition': '--partition={}',
             'num_nodes': '--nodes={}',
-            'time': '--time={}:00:00',
+            'time': '--time={}:00',
             'reservation': '--reservation={}',
             'mem': '--mem={}g',
             'account': '--account={}',
@@ -121,9 +121,7 @@ class CrcInteractive(BaseParser):
             'feature': '--constraint={}',
             'num_cores': '--cpus-per-task={}' if getattr(args, 'openmp') else '--ntasks-per-node={}'
         }
-        #Check if time specified in %H:%M format
-        if args.time.find(':')>-1:
-            srun_dict['time']='--time={}'
+     
         # Build a string of srun arguments
         srun_args = '--export=ALL'
         for app_arg_name, srun_arg_name in srun_dict.items():

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -83,7 +83,7 @@ class CrcInteractive(BaseParser):
 
         # Check wall time is between limits, enable both %H:%M format as well as integer hours
         check_time=0
-        if  args.time.isdecimal()::
+        if  args.time.isdecimal():
             check_time=int(args.time)+1
         else:
             check_time=datetime.strptime(args.time,'%H:%M').hour

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -84,9 +84,9 @@ class CrcInteractive(BaseParser):
         # Check wall time is between limits, enable both %H:%M format as well as integer hours
         check_time=0
         if  args.time.isdecimal():
-            check_time=int(args.time)+1
+            check_time=int(args.time)
         else:
-            check_time=datetime.strptime(args.time,'%H:%M').hour
+            check_time=datetime.strptime(args.time,'%H:%M').hour + float(datetime.strptime(args.time,'%H:%M').minute)/60
             
         if not self.min_time <= check_time <= self.max_time:
             self.error(f'{check_time} is not in {self.min_time} <= time <= {self.max_time}... exiting')

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -85,7 +85,7 @@ class CrcInteractive(BaseParser):
         check_time=0
         if args.time.find(':')<0:
             check_time=int(args.time)
-         else:
+        else:
             check_time=datetime.strptime(args.time,'%H:%M').hour
             
         if not self.min_time <= check_time <= self.max_time:

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -51,7 +51,7 @@ class CrcInteractive(BaseParser):
         resource_args = self.add_argument_group('Arguments for Increased Resources')
         resource_args.add_argument('-b', '--mem', type=int, default=self.default_mem, help='memory in GB')
         resource_args.add_argument(
-            '-t', '--time',  default=self.default_time,
+            '-t', '--time', default=self.default_time,
             help=f'run time in hours or hours:minutes [default: {self.default_time}]')
 
         resource_args.add_argument(
@@ -78,16 +78,15 @@ class CrcInteractive(BaseParser):
         """Exit the application if command line arguments are invalid
 
         Args:
-            args: Parsed commandl ine arguments
+            args: Parsed commandline arguments
         """
 
-        # Check wall time is between limits, enable both %H:%M format as well as integer hours
-        check_time=0
-        if  args.time.isdecimal():
-            check_time=int(args.time)
+        # Check wall time is between limits, enable both %H:%M format and integer hours
+        if args.time.isdecimal():
+            check_time = int(args.time)
         else:
-            check_time=datetime.strptime(args.time,'%H:%M').hour + float(datetime.strptime(args.time,'%H:%M').minute)/60
-            
+            check_time = datetime.strptime(args.time, '%H:%M').hour + float(datetime.strptime(args.time, '%H:%M').minute) // 60
+
         if not self.min_time <= check_time <= self.max_time:
             self.error(f'{check_time} is not in {self.min_time} <= time <= {self.max_time}... exiting')
 
@@ -121,7 +120,7 @@ class CrcInteractive(BaseParser):
             'feature': '--constraint={}',
             'num_cores': '--cpus-per-task={}' if getattr(args, 'openmp') else '--ntasks-per-node={}'
         }
-     
+
         # Build a string of srun arguments
         srun_args = '--export=ALL'
         for app_arg_name, srun_arg_name in srun_dict.items():


### PR DESCRIPTION
Enabled specification of both %H:%M format as well as integer hours for allocated time. The time argument is now treated as a string instead of an integer. Addresses issue #158. 