### PR TITLE
Add missing pyproject.toml script for crc-usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,16 @@ classifiers = [
 [tool.poetry.scripts]
 crc-idle = "apps.crc_idle:CrcIdle.execute"
 crc-interactive = "apps.crc_interactive:CrcInteractive.execute"
-crc-job_stats = "apps.crc_job_stats:CrcJobStats.execute"
-crc-proposal_end = "apps.crc_proposal_end:CrcProposalEnd.execute"
+crc-job-stats = "apps.crc_job_stats:CrcJobStats.execute"
+crc-proposal-end = "apps.crc_proposal_end:CrcProposalEnd.execute"
 crc-quota = "apps.crc_quota:CrcQuota.execute"
 crc-scancel = "apps.crc_scancel:CrcScancel.execute"
 crc-scontrol = "apps.crc_scontrol:CrcScontrol.execute"
-crc-show_config = "apps.crc_show_config:CrcShowConfig.execute"
+crc-show-config = "apps.crc_show_config:CrcShowConfig.execute"
 crc-sinfo = "apps.crc_sinfo:CrcSinfo.execute"
 crc-squeue = "apps.crc_squeue:CrcSqueue.execute"
 crc-sus = "apps.crc_sus:CrcSus.execute"
+crc-usage = "apps.crc_usage:CrcUsage.execute"
 
 [tool.poetry.dependencies]
 python = "^3.8.0"


### PR DESCRIPTION
The `crc-usage` application was missing from the pyproject.toml file so I added it. I also replaced any remaining underscores in the application names.