### PR TITLE
Updates signatures for utiliy classes

### DIFF
--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -9,7 +9,7 @@ from argparse import Namespace
 from typing import Dict, Tuple
 
 from ._base_parser import BaseParser
-from .utils.system_info import Shell, SlurmInfo
+from .utils.system_info import Shell, Slurm
 
 
 class CrcIdle(BaseParser):
@@ -176,6 +176,6 @@ class CrcIdle(BaseParser):
         """
 
         for cluster in self.get_cluster_list(args):
-            partitions_to_print = args.partition or SlurmInfo.get_partition_names(cluster)
+            partitions_to_print = args.partition or Slurm.get_partition_names(cluster)
             for partition in partitions_to_print:
                 self.print_partition_summary(cluster, partition)

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from os import system
 
 from ._base_parser import BaseParser
-from .utils.system_info import SlurmInfo
+from .utils.system_info import Slurm
 
 
 class CrcInteractive(BaseParser):
@@ -139,7 +139,7 @@ class CrcInteractive(BaseParser):
         if (args.gpu or args.invest) and args.num_gpus:
             srun_args += ' ' + f'--gres=gpu:{args.num_gpus}'
 
-        cluster_to_run = next(cluster for cluster in SlurmInfo.get_cluster_names() if getattr(args, cluster))
+        cluster_to_run = next(cluster for cluster in Slurm.get_cluster_names() if getattr(args, cluster))
         return f'srun -M {cluster_to_run} {srun_args} --pty bash'
 
     def app_logic(self, args: Namespace) -> None:
@@ -149,7 +149,7 @@ class CrcInteractive(BaseParser):
             args: Parsed command line arguments
         """
 
-        if not any(getattr(args, cluster, False) for cluster in SlurmInfo.get_cluster_names()):
+        if not any(getattr(args, cluster, False) for cluster in Slurm.get_cluster_names()):
             self.print_help()
             self.exit()
 

--- a/apps/crc_scancel.py
+++ b/apps/crc_scancel.py
@@ -9,7 +9,7 @@ import getpass
 from argparse import Namespace
 
 from ._base_parser import BaseParser
-from .utils.system_info import Shell, SlurmInfo
+from .utils.system_info import Shell, Slurm
 
 
 class CrcScancel(BaseParser):
@@ -54,7 +54,7 @@ class CrcScancel(BaseParser):
         # However, that approach fails for scavenger jobs. Instead, we iterate
         # over the clusters until we find the right one.
 
-        for cluster in SlurmInfo.get_cluster_names(include_all_clusters=True):
+        for cluster in Slurm.get_cluster_names(include_all_clusters=True):
             # Fetch a list of running slurm jobs matching the username and job id
             command = f'squeue -h -u {self.user} -j {job_id} -M {cluster}'
             if job_id in Shell.run_command(command):

--- a/apps/crc_show_config.py
+++ b/apps/crc_show_config.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 from typing import Dict
 
 from ._base_parser import BaseParser
-from .utils.system_info import Shell, SlurmInfo
+from .utils.system_info import Shell, Slurm
 
 
 class CrcShowConfig(BaseParser):
@@ -18,7 +18,7 @@ class CrcShowConfig(BaseParser):
         self.add_argument(
             '-c', '--cluster',
             required=True,
-            choices=SlurmInfo.get_cluster_names(),
+            choices=Slurm.get_cluster_names(),
             help='print partitions for the given cluster')
 
         self.add_argument('-p', '--partition', help='print information about nodes in the given partition')
@@ -78,7 +78,7 @@ class CrcShowConfig(BaseParser):
         """
 
         if args.partition:
-            if args.partition not in SlurmInfo.get_partition_names(args.cluster):
+            if args.partition not in Slurm.get_partition_names(args.cluster):
                 self.error(f'Partition {args.partition} is not part of cluster {args.cluster}')
 
             self.print_node(args.cluster, args.partition)

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -10,7 +10,7 @@ from typing import Dict
 import dataset
 
 from ._base_parser import BaseParser
-from .utils.system_info import Shell, SlurmInfo
+from .utils.system_info import Shell, Slurm
 
 
 class CrcSus(BaseParser):
@@ -47,7 +47,7 @@ class CrcSus(BaseParser):
             self.error('ERROR: No proposal for the given account was found')
 
         allocations = dict()
-        for cluster in SlurmInfo.get_cluster_names():
+        for cluster in Slurm.get_cluster_names():
             if cluster in db_record:
                 allocations[cluster] = db_record[cluster]
 

--- a/apps/utils/cli.py
+++ b/apps/utils/cli.py
@@ -1,9 +1,8 @@
 """Utility classes for building commandline parsers/applications."""
 
 import abc
-import logging
 import sys
-from argparse import ArgumentParser, HelpFormatter, Namespace
+from argparse import ArgumentParser, Namespace, HelpFormatter
 
 from .. import __version__
 
@@ -56,17 +55,18 @@ class CommandlineApplication(metaclass=abc.ABCMeta):
     2. The top level application logic via the ``app_logic`` method
     """
 
-    def app_interface(self) -> Parser:
+    def __init__(self):
+        """Initialize the commandline application"""
+
+        self.parser = Parser(description=self.__doc__.split('\n')[0])
+        self.app_interface(self.parser)
+
+    def app_interface(self, parser: Parser) -> None:
         """Define the application commandline interface
 
-        Factory method for creating commandline argument parsers with the
-        appropriate interface for the parent application.
-
-        Returns:
-            An instantiated commandline parser
+        Args:
+            parser: Argument parser used by the parent commandline application
         """
-
-        return Parser()
 
     @abc.abstractmethod
     def app_logic(self, args: Namespace) -> None:
@@ -81,7 +81,7 @@ class CommandlineApplication(metaclass=abc.ABCMeta):
         """Parse command line arguments and execute the application"""
 
         app = cls()
-        args = app.app_interface().parse_args()
+        args = app.parser.parse_args()
 
         try:
             app.app_logic(args)
@@ -91,4 +91,4 @@ class CommandlineApplication(metaclass=abc.ABCMeta):
             exit('User interrupt detected - exiting...')
 
         except Exception as excep:
-            logging.error(str(excep))
+            print(str(excep))

--- a/apps/utils/system_info.py
+++ b/apps/utils/system_info.py
@@ -59,7 +59,7 @@ class Shell:
         return out_decoded
 
 
-class SlurmInfo:
+class Slurm:
     """Class for fetching Slurm config data."""
 
     ignore_clusters = {'azure'}
@@ -74,6 +74,13 @@ class SlurmInfo:
         'isenocak-mpi',
         'power9'
     }
+
+    @staticmethod
+    def is_installed() -> bool:
+        """Return whether ``sacctmgr`` is installed on the host machine"""
+
+        cmd, err = Shell.run_command('sacctmgr --version', include_err=True)
+        return cmd and not err
 
     @classmethod
     def get_cluster_names(cls, include_all_clusters: bool = False) -> Set[str]:

--- a/tests/test_crc_idle.py
+++ b/tests/test_crc_idle.py
@@ -3,7 +3,7 @@
 from unittest import TestCase, skip
 
 from apps.crc_idle import CrcIdle
-from apps.utils.system_info import SlurmInfo
+from apps.utils.system_info import Slurm
 
 
 class ArgumentParsing(TestCase):
@@ -41,7 +41,7 @@ class ArgumentParsing(TestCase):
         args, unknown_args = app.parse_known_args([])
 
         self.assertFalse(unknown_args)
-        for cluster in SlurmInfo.get_cluster_names():
+        for cluster in Slurm.get_cluster_names():
             self.assertFalse(getattr(args, cluster))
 
 
@@ -57,7 +57,7 @@ class ClusterList(TestCase):
         self.assertFalse(unknown_args)
 
         returned_clusters = app.get_cluster_list(args)
-        self.assertCountEqual(SlurmInfo.get_cluster_names(), returned_clusters)
+        self.assertCountEqual(Slurm.get_cluster_names(), returned_clusters)
 
     def test_returns_arg_values(self) -> None:
         """Test returned cluster names match the clusters specified in the parsed arguments"""

--- a/tests/test_crc_show_config.py
+++ b/tests/test_crc_show_config.py
@@ -3,7 +3,7 @@
 from unittest import TestCase, skip
 
 from apps.crc_show_config import CrcShowConfig
-from apps.utils.system_info import SlurmInfo
+from apps.utils.system_info import Slurm
 
 
 class ArgumentParsing(TestCase):
@@ -15,7 +15,7 @@ class ArgumentParsing(TestCase):
 
         app = CrcShowConfig()
 
-        for cluster in SlurmInfo.get_cluster_names():
+        for cluster in Slurm.get_cluster_names():
             known_args, unknown_args = app.parse_known_args(['--cluster', cluster])
             self.assertEqual(cluster, known_args.cluster)
             self.assertFalse(unknown_args)

--- a/tests/utils/cli/test_commandline_application.py
+++ b/tests/utils/cli/test_commandline_application.py
@@ -27,4 +27,4 @@ class DefaultParser(TestCase):
             def app_logic(self, *args) -> None:
                 """A placeholder method"""
 
-        self.assertIsInstance(DummyApp().app_interface(), Parser)
+        self.assertIsInstance(DummyApp().parser, Parser)


### PR DESCRIPTION
Two major changes:

The ``CommandlineApplication.app_interface`` method is no longer a factory method. Instead it mutates a parser argument. This forces child classes to use the automatically provided parser (or explicitly override the default in the `__init__` method).

`SlurmInfo` has been renamed to `Slurm`.