### PR TITLE
Fixes bug where --version gives 0.0.0

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 
 try:
-    __version__ = importlib.metadata.version('quota-notifier')
+    __version__ = importlib.metadata.version('crc-wrappers')
 
 except importlib.metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = '0.0.0'


### PR DESCRIPTION
The package name was incorrect in `__init__.py`. This prevented the package from finding the correct version number.