### PR TITLE
HH:MM:SS time formatting bug in crc-interactive

### DIFF
--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -9,8 +9,8 @@ this application does support dynamic cluster discovery. New clusters need
 to be manually added (or removed) by updating the application CLI arguments.
 """
 
-from argparse import Namespace
-from datetime import datetime
+from argparse import Namespace, ArgumentTypeError
+from datetime import time
 from os import system
 
 from .utils.cli import BaseParser
@@ -25,7 +25,7 @@ class CrcInteractive(BaseParser):
     min_time = 1  # Minimum limit on requested time in hours
     max_time = 12  # Maximum limit on requested time in hours
 
-    default_time = '1:00'  # Default runtime
+    default_time = time(1)  # Default runtime
     default_nodes = 1  # Default number of nodes
     default_cores = 1  # Default number of requested cores
     default_mpi_cores = 28 # Default number of request cores on an MPI partition
@@ -54,8 +54,8 @@ class CrcInteractive(BaseParser):
         resource_args = self.add_argument_group('Arguments for Increased Resources')
         resource_args.add_argument('-b', '--mem', type=int, default=self.default_mem, help='memory in GB')
         resource_args.add_argument(
-            '-t', '--time', default=self.default_time,
-            help=f'run time in hours or hours:minutes [default: {self.default_time} hour] ')
+            '-t', '--time', type=self.parse_time, default=self.default_time,
+            help=f'run time in hours or hours:minutes [default: {self.default_time}] ')
 
         resource_args.add_argument(
             '-n', '--num-nodes', type=int, default=self.default_nodes,
@@ -77,6 +77,26 @@ class CrcInteractive(BaseParser):
         additional_args.add_argument('-f', '--feature', help='specify a feature, e.g. `ti` for GPUs')
         additional_args.add_argument('-o', '--openmp', action='store_true', help='run using OpenMP style submission')
 
+    @staticmethod
+    def parse_time(time_str: str) -> time:
+        """Parse a string representation of time in 'HH:MM:SS' format and return a time object
+
+        Args:
+            time_str: A string representing time in 'HH:MM:SS' format.
+
+        Returns:
+            time: A time object representing the parsed time.
+
+        Raises:
+            ArgumentTypeError: If the input string is not in the correct format or cannot be parsed.
+        """
+
+        try:
+            return time(*time_str.split(':')[0])
+
+        except Exception:
+            raise ArgumentTypeError(f'Could not parse time value {time_str}')
+
     def _validate_arguments(self, args: Namespace) -> None:
         """Exit the application if command line arguments are invalid
 
@@ -85,12 +105,7 @@ class CrcInteractive(BaseParser):
         """
 
         # Check wall time is between limits, enable both %H:%M format and integer hours
-        if args.time.isdecimal():
-            check_time = int(args.time)
-        else:
-            check_time = (
-                datetime.strptime(args.time, '%H:%M').hour +
-                datetime.strptime(args.time, '%H:%M').minute / 60)
+        check_time = args.time.hour + args.time.minute / 60 + args.time.second / 3600
 
         if not self.min_time <= check_time <= self.max_time:
             self.error(f'{check_time} is not in {self.min_time} <= time <= {self.max_time}... exiting')
@@ -122,7 +137,7 @@ class CrcInteractive(BaseParser):
         srun_dict = {
             'partition': '--partition={}',
             'num_nodes': '--nodes={}',
-            'time': '--time={}:00',
+            'time': '--time={}',
             'reservation': '--reservation={}',
             'mem': '--mem={}g',
             'account': '--account={}',


### PR DESCRIPTION
It seems when entering the decimal value for the parameter "-t" or "--time" in crc-interactive it's formatted in the srun_dict as "{}:00" which makes it interpreted as "MM:SS" but if using the string format "01:00" and it's formatted in the srun_dict as "{}:00" then it's interpreted as "HH:MM:SS" which is the necessary format for "srun". I added a possible fix, please take a look and feel free to discard it and fix it in any other way because I am sure this is not the best way to fix it, I was just trying to expose where the error comes from.