### PR TITLE
Adds tests for time parsing in crc-interactive

### DIFF
--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -28,7 +28,7 @@ class CrcInteractive(BaseParser):
     default_time = time(1)  # Default runtime
     default_nodes = 1  # Default number of nodes
     default_cores = 1  # Default number of requested cores
-    default_mpi_cores = 28 # Default number of request cores on an MPI partition
+    default_mpi_cores = 28  # Default number of request cores on an MPI partition
     default_mem = 1  # Default memory in GB
     default_gpus = 0  # Default number of GPUs
 
@@ -91,8 +91,12 @@ class CrcInteractive(BaseParser):
             ArgumentTypeError: If the input string is not in the correct format or cannot be parsed.
         """
 
+        time_list = time_str.split(':')
+        if len(time_list) > 3:
+            raise ArgumentTypeError(f'Could not parse time value {time_str}')
+
         try:
-            return time(*time_str.split(':')[0])
+            return time(*map(int, time_list))
 
         except Exception:
             raise ArgumentTypeError(f'Could not parse time value {time_str}')

--- a/tests/test_crc_interactive.py
+++ b/tests/test_crc_interactive.py
@@ -1,5 +1,8 @@
 """Tests for the ``crc-interactive`` application."""
 
+import unittest
+from argparse import ArgumentTypeError
+from datetime import time
 from unittest import TestCase
 
 from apps.crc_interactive import CrcInteractive
@@ -17,3 +20,46 @@ class ArgumentParsing(TestCase):
         self.assertEqual(CrcInteractive.default_cores, args.num_cores)
         self.assertEqual(CrcInteractive.default_mem, args.mem)
         self.assertEqual(CrcInteractive.default_gpus, args.num_gpus)
+
+
+class TestParseTime(unittest.TestCase):
+    """Test the parsing of time strings"""
+
+    def test_valid_time(self) -> None:
+        """Test the parsing of valid time strings"""
+
+        self.assertEqual(CrcInteractive.parse_time('1'), time(1, 0, 0))
+        self.assertEqual(CrcInteractive.parse_time('01'), time(1, 0, 0))
+        self.assertEqual(CrcInteractive.parse_time('23:59'), time(23, 59, 0))
+        self.assertEqual(CrcInteractive.parse_time('12:34:56'), time(12, 34, 56))
+
+    def test_invalid_time_format(self) -> None:
+        """Test an errr is raised for invalid time formatting"""
+
+        # Test with invalid time formats
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for invalid delimiter'):
+            CrcInteractive.parse_time('12-34-56')
+
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for too many digits'):
+            CrcInteractive.parse_time('123:456:789')
+
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for too many segments'):
+            CrcInteractive.parse_time('12:34:56:78')
+
+    def test_invalid_time_value(self) -> None:
+        """Test an errr is raised for invalid time values"""
+
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for invalid hour'):
+            CrcInteractive.parse_time('25:00:00')
+
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for invalid minute'):
+            CrcInteractive.parse_time('12:60:00')
+
+        with self.assertRaises(ArgumentTypeError, msg='Error not raised for invalid second'):
+            CrcInteractive.parse_time('12:34:60')
+
+    def test_empty_string(self) -> None:
+        """Test an error is raised for empty strings"""
+
+        with self.assertRaises(ArgumentTypeError):
+            CrcInteractive.parse_time('')


### PR DESCRIPTION
Adds test coverage for the `parse_time` method.