### PR TITLE
Show most recently expired allocation info when there are no active allocations

### DIFF
--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -40,7 +40,7 @@ class CrcProposalEnd(BaseParser):
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
 
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'")
+            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
             print("Showing end date for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -40,8 +40,8 @@ class CrcProposalEnd(BaseParser):
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
 
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
-            print("Showing end date for most recently expired Resource Allocation Request:")
+            print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
+            print("Showing end date for most recently expired Resource Allocation Request:\033[0m")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         for request in alloc_requests:

--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -40,7 +40,7 @@ class CrcProposalEnd(BaseParser):
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
 
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
+            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing end date for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -39,9 +39,10 @@ class CrcProposalEnd(BaseParser):
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
 
-        if not (keystone_group_id and requests):
+        if not alloc_requests:
             print(f"No active allocation information found in accounting system for '{args.account}'")
-            exit()
+            print("Showing end date for most recently expired Resource Allocation Request:")
+            alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         for request in alloc_requests:
-            print(f"Resource Allocation Request: '{request['title']}' ends on {request['expire']} ")
+            print(f"'{request['title']}' ends on {request['expire']} ")

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -64,9 +64,10 @@ class CrcSus(BaseParser):
         # Determine if provided or default account is in Keystone
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
-        if not (keystone_group_id and alloc_requests):
+        if not alloc_requests:
             print(f"No active allocation information found in accounting system for '{args.account}'")
-            exit()
+            print("Showing SUs for most recently expired Resource Allocation Request:")
+            alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         per_cluster_totals = get_per_cluster_totals(alloc_requests, auth_header)
         earliest_date = get_earliest_startdate(alloc_requests)

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -65,7 +65,7 @@ class CrcSus(BaseParser):
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
+            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing SUs for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -65,7 +65,7 @@ class CrcSus(BaseParser):
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'")
+            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
             print("Showing SUs for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -65,8 +65,8 @@ class CrcSus(BaseParser):
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
-            print("Showing SUs for most recently expired Resource Allocation Request:")
+            print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
+            print("Showing SUs for most recently expired Resource Allocation Request:\033[0m")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         per_cluster_totals = get_per_cluster_totals(alloc_requests, auth_header)

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -105,7 +105,7 @@ class CrcUsage(BaseParser):
 
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
+            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing usage information for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -102,15 +102,12 @@ class CrcUsage(BaseParser):
 
         # Gather AllocationRequests from Keystone
         keystone_group_id = get_researchgroup_id(KEYSTONE_URL, args.account, auth_header)
-        if not keystone_group_id:
-            print(f"No Slurm Account found in the accounting system for '{args.account}'. \n"
-                  f"Please submit a ticket to the CRC team to ensure your allocation was properly configured")
-            exit()
 
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
-        if not (keystone_group_id and alloc_requests):
-            print(f"No active allocation data found in the accounting system for '{args.account}'")
-            exit()
+        if not alloc_requests:
+            print(f"No active allocation information found in accounting system for '{args.account}'")
+            print("Showing usage information for most recently expired Resource Allocation Request:")
+            alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         self.print_summary_table(alloc_requests,
                                  args.account,

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -105,8 +105,8 @@ class CrcUsage(BaseParser):
 
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'!\n")
-            print("Showing usage information for most recently expired Resource Allocation Request:")
+            print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
+            print("Showing usage information for most recently expired Resource Allocation Request: \033[0m")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 
         self.print_summary_table(alloc_requests,

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -105,7 +105,7 @@ class CrcUsage(BaseParser):
 
         alloc_requests = get_active_requests(KEYSTONE_URL, keystone_group_id, auth_header)
         if not alloc_requests:
-            print(f"No active allocation information found in accounting system for '{args.account}'")
+            print(f"No active allocation information found in accounting system for '{args.account}!\n'")
             print("Showing usage information for most recently expired Resource Allocation Request:")
             alloc_requests = get_most_recent_expired_request(KEYSTONE_URL, keystone_group_id, auth_header)
 

--- a/apps/utils/keystone.py
+++ b/apps/utils/keystone.py
@@ -29,7 +29,9 @@ def get_active_requests(keystone_url: str, group_pk: int, auth_header: dict) -> 
     """Get all active AllocationRequest information from keystone for a given group"""
 
     today = date.today().isoformat()
-    response = requests.get(f"{keystone_url}/allocations/requests/?group={group_pk}&status=AP&active__lte={today}&expire__gt={today}", headers=auth_header)
+    response = requests.get(
+        f"{keystone_url}/allocations/requests/?group={group_pk}&status=AP&active__lte={today}&expire__gt={today}",
+        headers=auth_header)
     response.raise_for_status()
     return [request for request in response.json()]
 
@@ -66,7 +68,9 @@ def get_most_recent_expired_request(keystone_url: str, group_pk: int, auth_heade
     """Get the single most recently expired AllocationRequest information from keystone for a given group"""
 
     today = date.today().isoformat()
-    response = requests.get(f"{keystone_url}/allocations/requests/?ordering=-expire&group={group_pk}&status=AP&expire__lte={today}", headers=auth_header)
+    response = requests.get(
+        f"{keystone_url}/allocations/requests/?ordering=-expire&group={group_pk}&status=AP&expire__lte={today}",
+        headers=auth_header)
     response.raise_for_status()
 
     return [response.json()[0]]

--- a/apps/utils/keystone.py
+++ b/apps/utils/keystone.py
@@ -28,10 +28,10 @@ def get_request_allocations(keystone_url: str, request_pk: int, auth_header: dic
 def get_active_requests(keystone_url: str, group_pk: int, auth_header: dict) -> [dict]:
     """Get all active AllocationRequest information from keystone for a given group"""
 
-    response = requests.get(f"{keystone_url}/allocations/requests/?group={group_pk}&status=AP", headers=auth_header)
+    today = date.today().isoformat()
+    response = requests.get(f"{keystone_url}/allocations/requests/?group={group_pk}&status=AP&active__lte={today}&expire__gt={today}", headers=auth_header)
     response.raise_for_status()
-    return [request for request in response.json()
-            if date.fromisoformat(request['active']) <= date.today() < date.fromisoformat(request['expire'])]
+    return [request for request in response.json()]
 
 
 def get_researchgroup_id(keystone_url: str, account_name: str, auth_header: dict) -> int:
@@ -43,7 +43,9 @@ def get_researchgroup_id(keystone_url: str, account_name: str, auth_header: dict
     try:
         group_id = int(response.json()[0]['id'])
     except IndexError:
-        group_id = None
+        print(f"No Slurm Account found in the accounting system for '{account_name}'. \n"
+              f"Please submit a ticket to the CRC team to ensure your allocation was properly configured")
+        exit()
 
     return group_id
 
@@ -58,6 +60,16 @@ def get_earliest_startdate(alloc_requests: [dict]) -> date:
             earliest_date = start
 
     return earliest_date
+
+
+def get_most_recent_expired_request(keystone_url: str, group_pk: int, auth_header: dict) -> [dict]:
+    """Get the single most recently expired AllocationRequest information from keystone for a given group"""
+
+    today = date.today().isoformat()
+    response = requests.get(f"{keystone_url}/allocations/requests/?ordering=-expire&group={group_pk}&status=AP&expire__lte={today}", headers=auth_header)
+    response.raise_for_status()
+
+    return [response.json()[0]]
 
 
 def get_per_cluster_totals(alloc_requests: [dict], auth_header: dict, per_request: bool = False) -> dict:


### PR DESCRIPTION
This PR also ensures the wrappers are using the more advanced query parameters enabled by [Pitt-crc/keystone-api#](https://github.com/pitt-crc/keystone-api/pull/280)