### PR TITLE
Increase test coverage for crc-idle

### DIFF
--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -58,7 +58,7 @@ class CrcIdle(BaseParser):
         return specified_clusters or argument_clusters
 
     @staticmethod
-    def count_idle_cpu_resources(cluster: str, partition: str) -> dict[int, int]:
+    def _count_idle_cpu_resources(cluster: str, partition: str) -> dict[int, int]:
         """Return the idle CPU resources on a given cluster partition.
 
         Args:
@@ -83,7 +83,7 @@ class CrcIdle(BaseParser):
         return return_dict
 
     @staticmethod
-    def count_idle_gpu_resources(cluster: str, partition: str) -> dict[int, int]:
+    def _count_idle_gpu_resources(cluster: str, partition: str) -> dict[int, int]:
         """Return idle GPU resources on a given cluster partition.
 
         If the host node is in a `drain` state, the GPUs are reported as unavailable.
@@ -135,10 +135,10 @@ class CrcIdle(BaseParser):
 
         cluster_type = self.cluster_types[cluster]
         if cluster_type == 'GPUs':
-            return self.count_idle_gpu_resources(cluster, partition)
+            return self._count_idle_gpu_resources(cluster, partition)
 
         elif cluster_type == 'cores':
-            return self.count_idle_cpu_resources(cluster, partition)
+            return self._count_idle_cpu_resources(cluster, partition)
 
         raise ValueError(f'Unknown cluster type: {cluster}')
 

--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -9,8 +9,8 @@ import re
 from argparse import Namespace
 from collections import defaultdict
 
-from .utils.cli import BaseParser
 from .utils import Shell, Slurm
+from .utils.cli import BaseParser
 
 
 class CrcIdle(BaseParser):
@@ -59,56 +59,52 @@ class CrcIdle(BaseParser):
 
     @staticmethod
     def count_idle_cpu_resources(cluster: str, partition: str) -> dict[int, int]:
-        """Return the idle CPU resources on a given cluster partition
+        """Return the idle CPU resources on a given cluster partition.
 
         Args:
-            cluster: The cluster to print a summary for
-            partition: The partition in the parent cluster
+            cluster: The cluster to print a summary for.
+            partition: The partition in the parent cluster.
 
         Returns:
-            A dictionary mapping idle resources to number of nodes
+            A dictionary mapping the number of idle resources to the number of nodes with that many idle resources.
         """
 
         # Use `sinfo` command to determine the status of each node in the given partition
         command = f'sinfo -h -M {cluster} -p {partition} -N -o %N,%C'
-        stdout = Shell.run_command(command)
-        slurm_data = stdout.strip().split()
+        slurm_data = Shell.run_command(command).strip().split()
 
         # Count the number of nodes having a given number of idle cores/GPUs
         return_dict = dict()
         for node_info in slurm_data:
-            _, resource_data = node_info.split(',')  # Returns: node_name, resource_data
-            _, idle, _, _ = [int(x) for x in resource_data.split('/')]  # Returns: allocated, idle, other, total
+            node_name, resource_data = node_info.split(',')
+            allocated, idle, other, total = [int(x) for x in resource_data.split('/')]
             return_dict[idle] = return_dict.setdefault(idle, 0) + 1
 
         return return_dict
 
     @staticmethod
     def count_idle_gpu_resources(cluster: str, partition: str) -> dict[int, int]:
-        """Return idle GPU resources on a given cluster partition
+        """Return idle GPU resources on a given cluster partition.
 
         If the host node is in a `drain` state, the GPUs are reported as unavailable.
 
         Args:
-            cluster: The cluster to print a summary for
-            partition: The partition in the parent cluster
+            cluster: The cluster to print a summary for.
+            partition: The partition in the parent cluster.
 
         Returns:
-            A dictionary mapping idle resources to number of nodes
+            A dictionary mapping the number of idle resources to the number of nodes with that many idle resources.
         """
 
         # Use `sinfo` command to determine the status of each node in the given partition
-        command = f"sinfo -h -M {cluster} -p {partition} -N " \
-                  f"--Format=NodeList:'_',gres:5'_',gresUsed:12'_',StateCompact:' '"
-
-        stdout = Shell.run_command(command)
-        slurm_data = stdout.strip().split()
+        slurm_output_format = "NodeList:'_',gres:5'_',gresUsed:12'_',StateCompact:' '"
+        command = f"sinfo -h -M {cluster} -p {partition} -N --Format={slurm_output_format}"
+        slurm_data = Shell.run_command(command).strip().split()
 
         # Count the number of nodes having a given number of idle cores/GPUs
         return_dict = dict()
         for node_info in slurm_data:
-            # Returns: node_name, total, allocated, node state
-            _, total, allocated, state = node_info.split('_')
+            node_name, total, allocated, state = node_info.split('_')
 
             # If the node is in a downed state, report 0 resource availability.
             if re.search("drain", state):
@@ -124,17 +120,17 @@ class CrcIdle(BaseParser):
         return return_dict
 
     def count_idle_resources(self, cluster: str, partition: str) -> dict[int, int]:
-        """Determine the number of idle resources on a given cluster partition
+        """Determine the number of idle resources on a given cluster partition.
 
         The returned dictionary maps the number of idle resources (e.g., cores)
         to the number of nodes in the partition having that many resources idle.
 
         Args:
-            cluster: The cluster to print a summary for
-            partition: The partition in the parent cluster
+            cluster: The cluster to print a summary for.
+            partition: The partition in the parent cluster.
 
         Returns:
-            A dictionary mapping idle resources to number of nodes
+            A dictionary mapping idle resources to number of nodes.
         """
 
         cluster_type = self.cluster_types[cluster]
@@ -146,15 +142,14 @@ class CrcIdle(BaseParser):
 
         raise ValueError(f'Unknown cluster type: {cluster}')
 
-    def print_partition_summary(self, cluster: str, partition: str) -> None:
+    def print_partition_summary(self, cluster: str, partition: str, idle_resources: dict) -> None:
         """Print a summary of idle resources in a single partition
 
         Args:
             cluster: The cluster to print a summary for
             partition: The partition in the parent cluster
+            idle_resources: Dictionary mapping idle resources to number of nodes
         """
-
-        resource_allocation = self.count_idle_resources(cluster, partition)
 
         output_width = 30
         header = f'Cluster: {cluster}, Partition: {partition}'
@@ -162,22 +157,23 @@ class CrcIdle(BaseParser):
 
         print(header)
         print('=' * output_width)
-        for idle, nodes in sorted(resource_allocation.items()):
+        for idle, nodes in sorted(idle_resources.items()):
             print(f'{nodes:4d} nodes w/ {idle:3d} idle {unit}')
 
-        if not resource_allocation:
+        if not idle_resources:
             print(' No idle resources')
 
         print('')
 
     def app_logic(self, args: Namespace) -> None:
-        """Logic to evaluate when executing the application
+        """Logic to evaluate when executing the application.
 
         Args:
-            args: Parsed command line arguments
+            args: Parsed command line arguments.
         """
 
         for cluster in self.get_cluster_list(args):
             partitions_to_print = args.partition or Slurm.get_partition_names(cluster)
             for partition in partitions_to_print:
-                self.print_partition_summary(cluster, partition)
+                idle_resources = self.count_idle_resources(cluster, partition)
+                self.print_partition_summary(cluster, partition, idle_resources)

--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -16,7 +16,7 @@ from .utils.cli import BaseParser
 class CrcIdle(BaseParser):
     """Display idle Slurm resources."""
 
-    # The type of resource available on a cluster
+    # Specify the type of resource available on each cluster
     # Either `cores` or `GPUs` depending on the cluster type
     cluster_types = defaultdict(
         lambda: 'cores',

--- a/apps/utils/__init__.py
+++ b/apps/utils/__init__.py
@@ -1,1 +1,3 @@
 """The ``utils`` module defines helper utilities for building commandline system tools."""
+
+from .system_info import Shell, Slurm


### PR DESCRIPTION
Adds unit tests with improved test coverage for crc-idle. I'm mocking the number of idle resources returned by Slurm. This means the tests are limited in their ability to identify compatibility problems with Slurm. However, I don't see an easy way to set up idle resources in the test environment. 