### PR TITLE
Adding gres handling for teach in crc-interactive

### DIFF
--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -77,7 +77,7 @@ class CrcIdle(BaseParser):
         # Count the number of nodes having a given number of idle cores/GPUs
         return_dict = dict()
         for node_info in slurm_data:
-            node_name, resource_data, free_mem = node_info.split(',')
+            _, resource_data, free_mem = node_info.split(',')
             allocated, idle, other, total = [int(x) for x in resource_data.split('/')]
             if idle not in return_dict:
                 # Initialize a new entry for this idle count
@@ -116,7 +116,7 @@ class CrcIdle(BaseParser):
         # Count the number of nodes having a given number of idle cores/GPUs
         return_dict = dict()
         for node_info in slurm_data:
-            node_name, total, allocated, state, free_mem = node_info.split('_')
+            _, total, allocated, state, free_mem = node_info.split('_')
 
             # If the node is in a downed state, report 0 resource availability.
             if re.search("drain", state):

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -56,7 +56,8 @@ class CrcInteractive(BaseParser):
         cluster_args = self.add_argument_group('Cluster Arguments')
         cluster_args.add_argument('-p', '--partition', help='run the session on a specific partition')
         for cluster, abbrev in self.clusters.items():
-            cluster_args.add_argument(f'-{abbrev}', f'--{cluster}', action='store_true', help=f'launch a session on the {cluster} cluster')
+            cluster_args.add_argument(f'-{abbrev}', f'--{cluster}', action='store_true',
+                                      help=f'launch a session on the {cluster} cluster')
 
         # Arguments for requesting additional hardware resources
         resource_args = self.add_argument_group('Arguments for Increased Resources')
@@ -116,7 +117,7 @@ class CrcInteractive(BaseParser):
 
         # Set defaults that need to be determined dynamically
         if not args.num_gpus:
-            args.num_gpus = 1 if args.gpu else 0
+            args.num_gpus = 1 if (args.gpu or (args.teach and (args.partition == 'gpu'))) else 0
 
         # Check wall time is between limits, enable both %H:%M format and integer hours
         check_time = args.time.hour + args.time.minute / 60 + args.time.second / 3600
@@ -171,7 +172,7 @@ class CrcInteractive(BaseParser):
                 srun_args += ' ' + srun_arg_name.format(arg_value)
 
         # The --gres argument in srun needs some special handling so is missing from the above dict
-        if (args.gpu or args.invest) and args.num_gpus:
+        if (args.gpu or args.invest or (args.teach and (args.partition == 'gpu'))) and args.num_gpus:
             srun_args += ' ' + f'--gres=gpu:{args.num_gpus}'
 
         try:


### PR DESCRIPTION
Adding srun's gres parameter handling logic for teach in order to pass the requested gres and set the default num_gpus if not requested when c=teach and p=gpu