### PR TITLE
Treat expired requests as list to fix indexing error

### DIFF
--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -42,7 +42,7 @@ class CrcProposalEnd(BaseParser):
         if not alloc_requests:
             print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing end date for most recently expired Resource Allocation Request:\033[0m")
-            alloc_requests = get_most_recent_expired_request(keystone_session, group_id)
+            alloc_requests = [get_most_recent_expired_request(keystone_session, group_id)]
 
         for request in alloc_requests:
             print(f"'{request['title']}' ends on {request['expire']} ")

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -66,7 +66,7 @@ class CrcSus(BaseParser):
 
         if not alloc_requests:
             print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
-            print("Showing end date for most recently expired Resource Allocation Request:\033[0m")
+            print("Showing remaining service unit amounts for most recently expired Resource Allocation Request:\033[0m")
             alloc_requests = [get_most_recent_expired_request(keystone_session, group_id)]
 
         per_cluster_totals = get_per_cluster_totals(keystone_session, alloc_requests,

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -67,7 +67,7 @@ class CrcSus(BaseParser):
         if not alloc_requests:
             print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing end date for most recently expired Resource Allocation Request:\033[0m")
-            alloc_requests = get_most_recent_expired_request(keystone_session, group_id)
+            alloc_requests = [get_most_recent_expired_request(keystone_session, group_id)]
 
         per_cluster_totals = get_per_cluster_totals(keystone_session, alloc_requests,
                                                     get_enabled_cluster_ids(keystone_session))

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -107,7 +107,7 @@ class CrcUsage(BaseParser):
         if not alloc_requests:
             print(f"\033[91m\033[1mNo active allocation information found in accounting system for '{args.account}'!\n")
             print("Showing usage information for most recently expired Resource Allocation Request: \033[0m")
-            alloc_requests = get_most_recent_expired_request(keystone_session, group_id)
+            alloc_requests = [get_most_recent_expired_request(keystone_session, group_id)]
 
         clusters = get_enabled_cluster_ids(keystone_session)
 


### PR DESCRIPTION
Closes #262 

Looks like a mismatch between the expected and returned type of `get_most_recent_expired_request`.

@Comeani can you double check this works for you?