### PR TITLE
Fixing crc-idle for down CPU resources

### DIFF
--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -81,7 +81,7 @@ class CrcIdle(BaseParser):
 
             # If the node is in a downed state, report 0 resource availability.
             down_keys = ['down', 'drain']
-            if any(re.search(key, node_state) for key in down_keys):
+            if any(key in node_state for key in down_keys):
                 idle = 0
                 free_mem = 0
             else:

--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -71,14 +71,22 @@ class CrcIdle(BaseParser):
         """
 
         # Use `sinfo` command to determine the status of each node in the given partition
-        command = f'sinfo -h -M {cluster} -p {partition} -N -o %N,%C,%e'
+        command = f'sinfo -h -M {cluster} -p {partition} -N -o %N,%C,%e,%t'
         slurm_data = Shell.run_command(command).strip().split()
 
         # Count the number of nodes having a given number of idle cores/GPUs
         return_dict = dict()
         for node_info in slurm_data:
-            _, resource_data, free_mem = node_info.split(',')
-            allocated, idle, other, total = [int(x) for x in resource_data.split('/')]
+            _, resource_data, free_mem, node_state = node_info.split(',')
+
+            # If the node is in a downed state, report 0 resource availability.
+            down_keys = ['down', 'drain']
+            if any([re.search(key, node_state) for key in down_keys]):
+                idle = 0
+                free_mem = 0
+            else:
+                allocated, idle, other, total = [int(x) for x in resource_data.split('/')]
+
             if idle not in return_dict:
                 # Initialize a new entry for this idle count
                 return_dict[idle] = {

--- a/apps/crc_idle.py
+++ b/apps/crc_idle.py
@@ -81,7 +81,7 @@ class CrcIdle(BaseParser):
 
             # If the node is in a downed state, report 0 resource availability.
             down_keys = ['down', 'drain']
-            if any([re.search(key, node_state) for key in down_keys]):
+            if any(re.search(key, node_state) for key in down_keys):
                 idle = 0
                 free_mem = 0
             else:

--- a/tests/test_crc_idle.py
+++ b/tests/test_crc_idle.py
@@ -91,7 +91,7 @@ class CountIdleResources(TestCase):
 
     @patch('apps.utils.Shell.run_command')
     def test_count_down_cpu_resources(self, mock_run_command: Mock) -> None:
-        """Test counting down CPU resources."""
+        """Test counting CPU resources for nodes in a down or drained state."""
 
         cluster = 'smp'
         partition = 'default'

--- a/tests/test_crc_idle.py
+++ b/tests/test_crc_idle.py
@@ -79,7 +79,7 @@ class CountIdleResources(TestCase):
 
         cluster = 'smp'
         partition = 'default'
-        mock_run_command.return_value = "node1,2/4/0/4,3500\nnode2,3/2/0/3,4000"
+        mock_run_command.return_value = "node1,2/4/0/4,3500,mix\nnode2,3/2/0/3,4000,mix"
 
         app = CrcIdle()
         result = app.count_idle_resources(cluster, partition)
@@ -87,6 +87,20 @@ class CountIdleResources(TestCase):
         expected = {4: {'count': 1, 'min_free_mem': 3500, 'max_free_mem': 3500},
                     2: {'count': 1, 'min_free_mem': 4000, 'max_free_mem': 4000}
                     }
+        self.assertEqual(expected, result)
+
+    @patch('apps.utils.Shell.run_command')
+    def test_count_down_cpu_resources(self, mock_run_command: Mock) -> None:
+        """Test counting down CPU resources."""
+
+        cluster = 'smp'
+        partition = 'default'
+        mock_run_command.return_value = "node1,2/4/0/4,3500,down*\nnode2,3/2/0/3,4000,drain*"
+
+        app = CrcIdle()
+        result = app.count_idle_resources(cluster, partition)
+
+        expected = {0: {'count': 2, 'min_free_mem': 0, 'max_free_mem': 0}}
         self.assertEqual(expected, result)
 
     @patch('apps.utils.Shell.run_command')


### PR DESCRIPTION
Fixing crc-idle when nodes are in down or drain status for CPU resources. I added the "%t" option for the resource status in the sinfo command used and conditioned the parsing of the parsing of idle resources based on that.
