### PR TITLE
Tests for printing and output of crc-usage's Summary/Usage tables

### DIFF
--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -70,7 +70,7 @@ class CrcUsage(BaseParser):
                 usage_table.add_row(["", "", "", ""], divider=True)
                 continue
 
-            total_used = int(usage_by_user.pop('total', 0))
+            total_used = int(usage_by_user.pop('total'))
             percent_used = int((total_used / total_awarded * 100) // 1)
             usage_table.add_row(
                 [f"{cluster}", f"TOTAL USED: {total_used}", f"AWARDED: {total_awarded}", f"% USED: {percent_used}"],

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -70,7 +70,7 @@ class CrcUsage(BaseParser):
                 usage_table.add_row(["", "", "", ""], divider=True)
                 continue
 
-            total_used = int(usage_by_user.pop('total'))
+            total_used = int(usage_by_user.pop('total', 0))
             percent_used = int((total_used / total_awarded * 100) // 1)
             usage_table.add_row(
                 [f"{cluster}", f"TOTAL USED: {total_used}", f"AWARDED: {total_awarded}", f"% USED: {percent_used}"],

--- a/tests/test_crc_usage.py
+++ b/tests/test_crc_usage.py
@@ -2,7 +2,8 @@
 
 import grp
 import os
-from unittest import TestCase, skipIf
+from datetime import date
+from unittest import TestCase, skipIf, mock
 
 from apps.crc_usage import CrcUsage
 from apps.utils.system_info import Slurm
@@ -37,3 +38,129 @@ class MissingAccountError(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, f"No Slurm account was found with the name 'dummy_account'."):
             app.app_logic(args)
+
+
+class PrintSummaryTable(TestCase):
+    """Test the `print_summary_table` method"""
+
+    def setUp(self) -> None:
+        """Set up the test environment with mock Slurm data"""
+
+        self.account_name = 'test_account'
+        self.alloc_requests = [
+            {'id': 1, 'title': 'Request 1', 'expire': '2023-12-31'},
+            {'id': 2, 'title': 'Request 2', 'expire': '2024-12-31'}
+        ]
+        self.per_request_totals = {
+            1: {'cluster1': 1000, 'cluster2': 2000},
+            2: {'cluster1': 1500, 'cluster2': 2500}
+        }
+
+    def test_summary_table_printed(self) -> None:
+        """Test the summary table is created and printed"""
+
+        with mock.patch('builtins.print') as mock_print:
+            CrcUsage.print_summary_table(self.alloc_requests, self.account_name, self.per_request_totals)
+
+            self.assertTrue(mock_print.called)
+
+    def test_summary_table_values(self) -> None:
+        """Test the summary table contains the correct headers"""
+
+        with mock.patch('builtins.print') as mock_print:
+            CrcUsage.print_summary_table(self.alloc_requests, self.account_name, self.per_request_totals)
+
+            # Capture the printed output
+            printed_output = "\n".join([str(call[0][0]) for call in mock_print.call_args_list])
+            print("Printed output:", printed_output)
+
+            # Verify the table headers
+            self.assertIn("Resource Allocation Request Information for 'test_account'", printed_output)
+            self.assertIn("ID", printed_output)
+            self.assertIn("TITLE", printed_output)
+            self.assertIn("EXPIRATION DATE", printed_output)
+            self.assertIn("CLUSTER", printed_output)
+            self.assertIn("SERVICE UNITS", printed_output)
+
+            # Verify specific rows
+            self.assertIn("1", printed_output) # ID
+            self.assertIn("Request 1", printed_output) # Title
+            self.assertIn("2023-12-31", printed_output) # Expiration Date
+            self.assertIn("cluster1", printed_output) # Cluster
+            self.assertIn("1000", printed_output) # Service units
+
+            self.assertIn("2", printed_output) # ID
+            self.assertIn("Request 2", printed_output) # Title
+            self.assertIn("2024-12-31", printed_output)  # Expiration Date
+            self.assertIn("cluster2", printed_output) # Cluster
+            self.assertIn("2500", printed_output) # Service Units
+
+
+class PrintUsageTable(TestCase):
+    """Test the `print_usage_table` method"""
+
+    def setUp(self) -> None:
+        """Set up the test environment with mock Slurm data"""
+
+        self.account_name = 'test_account'
+        self.awarded_totals = {'cluster1': 1000, 'cluster2': 2000}
+        self.earliest_date = date(2023, 1, 1)
+
+    @mock.patch('apps.utils.system_info.Slurm.get_cluster_usage_by_user')
+    def test_usage_table_printed(self, mock_get_usage) -> None:
+        """Test the creation and formatting of the usage table"""
+
+        mock_get_usage.side_effect = lambda *args, **kwargs: {
+            'user1': 100,
+            'user2': 200,
+            'total': 300
+        }
+
+        print("Mocked return value:", mock_get_usage.return_value)
+
+        with mock.patch('builtins.print') as mock_print:
+            CrcUsage.print_usage_table(self.account_name, self.awarded_totals, self.earliest_date)
+
+            self.assertTrue(mock_print.called)
+
+            # Capture the printed output
+            printed_output = "\n".join([str(call[0][0]) for call in mock_print.call_args_list])
+
+            # Verify the table contains the expected data
+            # User 1 on Cluster 1
+            self.assertIn("TOTAL USED: 300", printed_output) # Total Used
+            self.assertIn("AWARDED: 1000", printed_output) # Total Awarded
+            self.assertIn("% USED: 30", printed_output) # Total % Used
+            self.assertIn("user1", printed_output) # User
+            self.assertIn("100", printed_output) # Used
+            self.assertIn("10", printed_output)  # % Used
+
+            # User 2 on Cluster 2
+            self.assertIn("TOTAL USED: 300", printed_output)  # Total Used
+            self.assertIn("AWARDED: 2000", printed_output)  # Total Awarded
+            self.assertIn("% USED: 15", printed_output)  # Total % Used
+            self.assertIn("user2", printed_output)  # User
+            self.assertIn("200", printed_output)  # Used
+            self.assertIn("10", printed_output)  # % Used
+
+    @mock.patch('apps.utils.system_info.Slurm.get_cluster_usage_by_user')
+    def test_print_usage_table_no_data(self, mock_get_usage) -> None:
+        """Test the usage table when no usage data is available"""
+
+        # Mock no usage data
+        mock_get_usage.return_value = None
+
+        # Mock the print function to capture output
+        with mock.patch('builtins.print') as mock_print:
+            CrcUsage.print_usage_table(self.account_name, self.awarded_totals, self.earliest_date)
+
+            # Verify the table was printed
+            self.assertTrue(mock_print.called)
+
+            # Capture the printed output
+            printed_output = "\n".join([str(call[0][0]) for call in mock_print.call_args_list])
+
+            # Verify the table contains the expected message for no data
+            self.assertIn("TOTAL USED: 0", printed_output)
+            self.assertIn("AWARDED: 1000", printed_output)
+            self.assertIn("% USED: 0", printed_output)


### PR DESCRIPTION
I noticed crc-usage was the file with the least test coverage reported to codacy, an figured I should at least add some tests making sure the tables are consistently printed and generally contain the correct output values. 

These might need some refinement but should hit the printing functionality downstream of the app logic's initial interactions with Slurm and Keystone.


The initial way I was mocking the output of `get_cluster_usage_by_user` was causing `total` to be missing from the dictionary on the second cluster, hence I use a `side_effect` there instead of `return_value`. I had changed it so `print_usage_table` would default `total_used` to 0 if it couldn't find the `total` key in `usage_by_user`. I don't think that should ever be the case when the function runs normally, but I realized just returning 0 might cover up something actually being broken and decided against it.  