### PR TITLE
TRES -> AllocTRES when constructing job stats output

### DIFF
--- a/apps/crc_job_stats.py
+++ b/apps/crc_job_stats.py
@@ -82,7 +82,7 @@ class CrcJobStats(BaseParser):
         print('')
 
         # Print metrics for running jobs
-        for item in ('JobId', 'SubmitTime', 'EndTime', 'RunTime', 'TRES', 'Partition', 'NodeList', 'Command'):
+        for item in ('JobId', 'SubmitTime', 'EndTime', 'RunTime', 'AllocTRES', 'Partition', 'NodeList', 'Command'):
             print(f'{item:>16s}: {job_info[item]}')
 
         # Add the more information section


### PR DESCRIPTION
@djperrefort This should address that issue you showed me earlier:

```
(wrappers_env) [nlc60@smp-n251 apps] fix_jobstats : crc-job-stats 
==============================================================================
                                JOB STATISTICS                                
==============================================================================

           JobId: 20202315
      SubmitTime: 2025-06-18T15:32:21
         EndTime: 2025-06-18T16:32:22
         RunTime: 00:10:28
usage: crc-job-stats [-h] [-v]

Track job information from within a Slurm job. Include this command at the end of your Slurm job scripts.

optional arguments:
  -h, --help     show this help message and exit
  -v, --version  show program's version number and exit
'TRES'
```

Running after this change yields:

```
(wrappers_env) [nlc60@smp-n251 apps] fix_jobstats : crc-job-stats 
==============================================================================
                                JOB STATISTICS                                
==============================================================================

           JobId: 20202315
      SubmitTime: 2025-06-18T15:32:21
         EndTime: 2025-06-18T16:32:22
         RunTime: 00:10:46
       AllocTRES: cpu=1,mem=1G,node=1
       Partition: smp
        NodeList: smp-n251
         Command: bash

==============================================================================
 For more information use the command:
   - `sacct -M smp -j 20202315 -S 2025-06-18T15:32:21 -E 2025-06-18T16:32:22`

 To control the output of the above command:
   - Add `--format=<field1,field2,etc>` with fields of interest
   - See the list of all possible fields by running: `sacct --helpformat`
==============================================================================
```
We can try to come up with a more robust way to parse the fields from the scontrol output another time.
