### PR TITLE
Improve error message on Keystone authentication failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,13 +84,6 @@ ipython_config.py
 # pyenv
 .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
@@ -130,3 +123,6 @@ dmypy.json
 
 # Pycharm file
 .idea/
+
+# System Files
+.DS_Store

--- a/apps/crc_interactive.py
+++ b/apps/crc_interactive.py
@@ -15,7 +15,7 @@ from .utils.system_info import Slurm
 
 
 class CrcInteractive(BaseParser):
-    """Launch an interactive Slurm session on a user-selected cluster."""
+    """Launch an interactive Slurm session on a cluster."""
 
     min_mpi_nodes = 2  # Minimum limit on requested MPI nodes
     min_mpi_cores = defaultdict(lambda: 28, {'mpi': 48, 'opa-high-mem': 28})  # Minimum cores per MPI partition

--- a/apps/crc_proposal_end.py
+++ b/apps/crc_proposal_end.py
@@ -9,10 +9,8 @@ import os
 from argparse import Namespace
 from getpass import getpass
 
-from keystone_client import KeystoneClient
-
 from .utils.cli import BaseParser
-from .utils.keystone import (get_active_requests, get_most_recent_expired_request, KEYSTONE_URL)
+from .utils.keystone import (authenticate_keystone_session, get_active_requests, get_most_recent_expired_request)
 from .utils.system_info import Slurm
 
 
@@ -39,8 +37,7 @@ class CrcProposalEnd(BaseParser):
 
         Slurm.check_slurm_account_exists(args.account)
 
-        keystone_session = KeystoneClient(base_url=KEYSTONE_URL)
-        keystone_session.login(
+        keystone_session = authenticate_keystone_session(
             username=os.environ["USER"],
             password=getpass("Please enter your CRCD login password:\n")
         )

--- a/apps/crc_sus.py
+++ b/apps/crc_sus.py
@@ -10,16 +10,14 @@ import os
 from argparse import Namespace
 from getpass import getpass
 
-from keystone_client import KeystoneClient
-
 from .utils.cli import BaseParser
 from .utils.keystone import (
+    authenticate_keystone_session,
     get_active_requests,
     get_earliest_startdate,
     get_enabled_cluster_ids,
     get_most_recent_expired_request,
-    get_per_cluster_totals,
-    KEYSTONE_URL)
+    get_per_cluster_totals)
 from .utils.system_info import Slurm
 
 
@@ -69,8 +67,7 @@ class CrcSus(BaseParser):
 
         Slurm.check_slurm_account_exists(account_name=args.account)
 
-        session = KeystoneClient(base_url=KEYSTONE_URL)
-        session.login(
+        session = authenticate_keystone_session(
             username=os.environ['USER'],
             password=getpass('Please enter your CRCD login password:\n')
         )

--- a/apps/crc_usage.py
+++ b/apps/crc_usage.py
@@ -10,11 +10,11 @@ import os
 from argparse import Namespace
 from getpass import getpass
 
-from keystone_client import KeystoneClient
 from prettytable import PrettyTable
 
 from .utils.cli import BaseParser
 from .utils.keystone import (
+    authenticate_keystone_session,
     get_active_requests,
     get_earliest_startdate,
     get_enabled_cluster_ids,
@@ -109,8 +109,7 @@ class CrcUsage(BaseParser):
 
         Slurm.check_slurm_account_exists(account_name=args.account)
 
-        session = KeystoneClient(base_url=KEYSTONE_URL)
-        session.login(
+        session = authenticate_keystone_session(
             username=os.environ['USER'],
             password=getpass('Please enter your CRCD login password:\n')
         )

--- a/apps/utils/cli.py
+++ b/apps/utils/cli.py
@@ -49,11 +49,8 @@ class BaseParser(ArgumentParser, metaclass=abc.ABCMeta):
         """Handle errors and exit the application
 
         This method mimics the parent class behavior except error messages
-        are included in the raised ``SystemExit`` exception. This makes for
+        are included in the raised `SystemExit` exception. This makes for
         easier testing/debugging.
-
-        If the application was called without any commandline arguments, the
-        application help text is printed before exiting.
 
         Args:
             message: The error message
@@ -62,11 +59,15 @@ class BaseParser(ArgumentParser, metaclass=abc.ABCMeta):
             SystemExit: Every time the method is run
         """
 
-        # If no commandline arguments were given, print the help text
-        if len(sys.argv) == 1:
-            self.print_help()
-
         raise SystemExit(message)
+
+    def print_help_if_no_args(self) -> None:
+        """Print help text and exit if no arguments were provided but some are required."""
+
+        has_required_args = any(action.required for action in self._actions)
+        if len(sys.argv) == 1 and has_required_args:
+            self.print_help()
+            self.exit()
 
     @classmethod
     def execute(cls, args: Optional[List[str]] = None) -> None:
@@ -78,6 +79,7 @@ class BaseParser(ArgumentParser, metaclass=abc.ABCMeta):
 
         app = cls()
         args = app.parse_args(args)
+        app.print_help_if_no_args()
 
         try:
             app.app_logic(args)

--- a/apps/utils/keystone.py
+++ b/apps/utils/keystone.py
@@ -16,6 +16,31 @@ KEYSTONE_AUTH_ENDPOINT = 'authentication/new/'
 RAWUSAGE_RESET_DATE = date.fromisoformat('2024-05-07')
 
 
+def authenticate_keystone_session(username: str, password: str) -> KeystoneClient:
+    """Create and return an authenticated Keystone client session.
+
+    Args:
+        username: The username to authenticate with.
+        password: The password to authenticate with.
+
+    Returns:
+        An authenticated Keystone client session.
+    """
+
+    session = KeystoneClient(base_url=KEYSTONE_URL)
+
+    try:
+        session.login(username=username, password=password)
+
+    except Exception:
+        raise ValueError(
+            'ERROR: authentication failed. '
+            'Please check your username and password and try again.'
+        )
+
+    return session
+
+
 def get_account_id(session: KeystoneClient, account_name: str) -> int:
     """Return the account ID associated with a given account name.
 


### PR DESCRIPTION
Previously, authentication failures in `crc-proposal-end`, `crc-sus`, and `crc-usage` would surface as raw HTTP 400 exceptions with no user-friendly context. This PR introduces a shared `authenticate_keystone_session` helper in `utils/keystone.py` that catches authentication errors and presents a clear message directing the user to check their credentials. As part of this change, `BaseParser.error` was refactored to no longer print help text on runtime errors, preventing the help text from appearing alongside the new auth failure message.